### PR TITLE
feat: add category API endpoints

### DIFF
--- a/prisma/migrations/20251001120000_add_category_path/migration.sql
+++ b/prisma/migrations/20251001120000_add_category_path/migration.sql
@@ -1,0 +1,6 @@
+-- Add path column to Category and backfill existing rows
+ALTER TABLE "public"."Category"
+  ADD COLUMN "path" TEXT NOT NULL DEFAULT '';
+
+UPDATE "public"."Category"
+SET "path" = "slug";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,6 +40,7 @@ model Category {
   id        String     @id @default(cuid())
   name      String
   slug      String     @unique
+  path      String     @default("")
   parentId  String?
   parent    Category?  @relation("CatTree", fields: [parentId], references: [id])
   children  Category[] @relation("CatTree")

--- a/src/app/api/categories/[id]/rebuild-paths/route.ts
+++ b/src/app/api/categories/[id]/rebuild-paths/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+
+import { rebuildCategorySubtreePaths } from "../../../../../../lib/category-path";
+import { prisma } from "../../../../../../lib/prisma";
+import { handleApiError, NotFoundError } from "../../_utils";
+
+interface RouteParams {
+  params: {
+    id: string;
+  };
+}
+
+export async function POST(_request: Request, { params }: RouteParams) {
+  const categoryId = params.id;
+
+  try {
+    const exists = await prisma.category.findUnique({
+      where: { id: categoryId },
+      select: { id: true },
+    });
+
+    if (!exists) {
+      throw new NotFoundError("Category not found");
+    }
+
+    await prisma.$transaction(async (tx) => {
+      await rebuildCategorySubtreePaths(categoryId, tx);
+    });
+
+    const category = await prisma.category.findUnique({ where: { id: categoryId } });
+
+    return NextResponse.json({
+      message: "Category paths rebuilt",
+      category,
+    });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/src/app/api/categories/[id]/route.ts
+++ b/src/app/api/categories/[id]/route.ts
@@ -1,0 +1,125 @@
+import { Prisma } from "@prisma/client";
+import { NextResponse } from "next/server";
+
+import { rebuildCategorySubtreePaths } from "../../../../../lib/category-path";
+import { prisma } from "../../../../../lib/prisma";
+import { updateCategorySchema } from "../../../../../lib/validation.category";
+import {
+  BadRequestError,
+  NotFoundError,
+  buildSlugBase,
+  ensureValidParent,
+  generateUniqueCategorySlug,
+  handleApiError,
+  parseJsonBody,
+} from "../_utils";
+
+interface RouteParams {
+  params: {
+    id: string;
+  };
+}
+
+export async function PATCH(request: Request, { params }: RouteParams) {
+  const categoryId = params.id;
+
+  try {
+    const payload = await parseJsonBody(request, updateCategorySchema);
+
+    const updatedCategory = await prisma.$transaction(async (tx) => {
+      const existing = await tx.category.findUnique({ where: { id: categoryId } });
+
+      if (!existing) {
+        throw new NotFoundError("Category not found");
+      }
+
+      const data: Prisma.CategoryUpdateInput = {};
+      let shouldRebuildPaths = false;
+
+      if (payload.name && payload.name !== existing.name) {
+        const slugBase = buildSlugBase(payload.name);
+        const slug = await generateUniqueCategorySlug(slugBase, tx, categoryId);
+
+        data.name = payload.name;
+        data.slug = slug;
+        shouldRebuildPaths = true;
+      }
+
+      if (payload.sortOrder !== undefined) {
+        data.sortOrder = payload.sortOrder;
+      }
+
+      if (payload.parentId !== undefined) {
+        const parentId = payload.parentId ?? null;
+
+        if (parentId !== existing.parentId) {
+          await ensureValidParent(tx, parentId, categoryId);
+          data.parentId = parentId;
+          shouldRebuildPaths = true;
+        }
+      }
+
+      if (Object.keys(data).length === 0) {
+        return existing;
+      }
+
+      const updated = await tx.category.update({
+        where: { id: categoryId },
+        data,
+      });
+
+      if (shouldRebuildPaths) {
+        await rebuildCategorySubtreePaths(categoryId, tx);
+
+        const refreshed = await tx.category.findUnique({ where: { id: categoryId } });
+
+        if (!refreshed) {
+          throw new NotFoundError("Category not found");
+        }
+
+        return refreshed;
+      }
+
+      return updated;
+    });
+
+    return NextResponse.json(updatedCategory);
+  } catch (error) {
+    return handleApiError(error);
+  }
+}
+
+export async function DELETE(_request: Request, { params }: RouteParams) {
+  const categoryId = params.id;
+
+  try {
+    const result = await prisma.$transaction(async (tx) => {
+      const existing = await tx.category.findUnique({ where: { id: categoryId } });
+
+      if (!existing) {
+        throw new NotFoundError("Category not found");
+      }
+
+      const [childCount, productCount] = await Promise.all([
+        tx.category.count({ where: { parentId: categoryId } }),
+        tx.product.count({ where: { categoryId } }),
+      ]);
+
+      if (childCount > 0) {
+        throw new BadRequestError("Cannot delete category with child categories");
+      }
+
+      if (productCount > 0) {
+        throw new BadRequestError("Cannot delete category with products");
+      }
+
+      await tx.category.delete({ where: { id: categoryId } });
+
+      return { message: "Category deleted" };
+    });
+
+    return NextResponse.json(result);
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/src/app/api/categories/_utils.ts
+++ b/src/app/api/categories/_utils.ts
@@ -1,0 +1,149 @@
+import type { Prisma, PrismaClient } from "@prisma/client";
+import { Prisma as PrismaNamespace } from "@prisma/client";
+import { NextResponse } from "next/server";
+import type { ZodSchema } from "zod";
+
+import { slugify } from "../../../../lib/slug";
+
+export class ApiError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+  }
+}
+
+export class BadRequestError extends ApiError {
+  constructor(message: string) {
+    super(400, message);
+  }
+}
+
+export class NotFoundError extends ApiError {
+  constructor(message: string) {
+    super(404, message);
+  }
+}
+
+export type CategoryClient =
+  | Pick<PrismaClient, "category">
+  | Pick<Prisma.TransactionClient, "category">;
+
+export async function parseJsonBody<T>(
+  request: Request,
+  schema: ZodSchema<T>
+): Promise<T> {
+  let payload: unknown;
+
+  try {
+    payload = await request.json();
+  } catch {
+    throw new BadRequestError("Invalid JSON body");
+  }
+
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new BadRequestError("Request body must be a JSON object");
+  }
+
+  const parsed = schema.safeParse(payload);
+
+  if (!parsed.success) {
+    const message = parsed.error.errors.map((err) => err.message).join(", ");
+    throw new BadRequestError(message);
+  }
+
+  return parsed.data;
+}
+
+export function buildSlugBase(name: string): string {
+  const base = slugify(name);
+  return base.length > 0 ? base : "category";
+}
+
+export async function generateUniqueCategorySlug(
+  base: string,
+  prisma: CategoryClient,
+  excludeId?: string
+): Promise<string> {
+  const normalized = base.length > 0 ? base : "category";
+  let candidate = normalized;
+  let suffix = 2;
+
+  while (true) {
+    const existing = await prisma.category.findUnique({
+      where: { slug: candidate },
+      select: { id: true },
+    });
+
+    if (!existing || existing.id === excludeId) {
+      return candidate;
+    }
+
+    candidate = `${normalized}-${suffix}`;
+    suffix += 1;
+  }
+}
+
+export async function ensureValidParent(
+  prisma: CategoryClient,
+  parentId: string | null,
+  currentId?: string
+): Promise<void> {
+  if (!parentId) {
+    return;
+  }
+
+  if (currentId && parentId === currentId) {
+    throw new BadRequestError("Category cannot be its own parent");
+  }
+
+  let cursor: string | null = parentId;
+
+  while (cursor) {
+    const parent = await prisma.category.findUnique({
+      where: { id: cursor },
+      select: { id: true, parentId: true },
+    });
+
+    if (!parent) {
+      throw new BadRequestError("Parent category not found");
+    }
+
+    if (currentId && parent.id === currentId) {
+      throw new BadRequestError(
+        "Cannot set category as a descendant of itself"
+      );
+    }
+
+    cursor = parent.parentId ?? null;
+  }
+}
+
+export function handleApiError(error: unknown) {
+  if (error instanceof ApiError) {
+    return NextResponse.json({ message: error.message }, { status: error.status });
+  }
+
+  if (error instanceof PrismaNamespace.PrismaClientKnownRequestError) {
+    if (error.code === "P2002") {
+      return NextResponse.json(
+        { message: "Category with this slug already exists" },
+        { status: 400 }
+      );
+    }
+
+    if (error.code === "P2025") {
+      return NextResponse.json(
+        { message: "Category not found" },
+        { status: 404 }
+      );
+    }
+  }
+
+  console.error(error);
+  return NextResponse.json(
+    { message: "Internal server error" },
+    { status: 500 }
+  );
+}

--- a/src/app/api/categories/reorder/route.ts
+++ b/src/app/api/categories/reorder/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+
+import { prisma } from "../../../../../lib/prisma";
+import { reorderCategorySchema } from "../../../../../lib/validation.category";
+import {
+  BadRequestError,
+  handleApiError,
+  parseJsonBody,
+} from "../_utils";
+
+export async function POST(request: Request) {
+  try {
+    const payload = await parseJsonBody(request, reorderCategorySchema);
+    const parentId = payload.parentId ?? null;
+
+    await prisma.$transaction(async (tx) => {
+      if (new Set(payload.orderedIds).size !== payload.orderedIds.length) {
+        throw new BadRequestError("orderedIds must be unique");
+      }
+
+      if (payload.orderedIds.length === 0) {
+        return;
+      }
+
+      const categories = await tx.category.findMany({
+        where: { id: { in: payload.orderedIds } },
+        select: { id: true, parentId: true },
+      });
+
+      if (categories.length !== payload.orderedIds.length) {
+        throw new BadRequestError("One or more categories were not found");
+      }
+
+      for (const category of categories) {
+        const expectedParent = category.parentId ?? null;
+        if (expectedParent !== parentId) {
+          throw new BadRequestError(
+            "All categories must belong to the specified parent"
+          );
+        }
+      }
+
+      await Promise.all(
+        payload.orderedIds.map((id, index) =>
+          tx.category.update({
+            where: { id },
+            data: { sortOrder: index },
+          })
+        )
+      );
+    });
+
+    return NextResponse.json({ message: "Reordered categories" });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -1,0 +1,120 @@
+import { NextResponse } from "next/server";
+
+import { buildCategoryPath } from "../../../../lib/category-path";
+import { prisma } from "../../../../lib/prisma";
+import { createCategorySchema } from "../../../../lib/validation.category";
+
+import {
+  buildSlugBase,
+  ensureValidParent,
+  generateUniqueCategorySlug,
+  handleApiError,
+  parseJsonBody,
+} from "./_utils";
+
+interface CategoryNode {
+  id: string;
+  name: string;
+  slug: string;
+  path: string;
+  parentId: string | null;
+  sortOrder: number;
+  createdAt: Date;
+  updatedAt: Date;
+  children: CategoryNode[];
+}
+
+function sortNodes(nodes: CategoryNode[]): CategoryNode[] {
+  return nodes
+    .sort((a, b) => {
+      if (a.sortOrder !== b.sortOrder) {
+        return a.sortOrder - b.sortOrder;
+      }
+
+      return a.name.localeCompare(b.name);
+    })
+    .map((node) => ({
+      ...node,
+      children: sortNodes(node.children),
+    }));
+}
+
+export async function GET() {
+  try {
+    const categories = await prisma.category.findMany();
+
+    const childrenByParent = new Map<string | null, CategoryNode[]>();
+
+    for (const category of categories) {
+      const node: CategoryNode = {
+        ...category,
+        children: [],
+      };
+
+      const parentKey = category.parentId ?? null;
+      const siblings = childrenByParent.get(parentKey) ?? [];
+      siblings.push(node);
+      childrenByParent.set(parentKey, siblings);
+    }
+
+    function buildTree(parentId: string | null): CategoryNode[] {
+      const children = childrenByParent.get(parentId) ?? [];
+
+      for (const child of children) {
+        child.children = buildTree(child.id);
+      }
+
+      return sortNodes(children);
+    }
+
+    const tree = buildTree(null);
+
+    return NextResponse.json(tree);
+  } catch (error) {
+    return handleApiError(error);
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const payload = await parseJsonBody(request, createCategorySchema);
+
+    const createdCategory = await prisma.$transaction(async (tx) => {
+      const parentId = payload.parentId ?? null;
+      await ensureValidParent(tx, parentId);
+
+      const slugBase = buildSlugBase(payload.name);
+      const slug = await generateUniqueCategorySlug(slugBase, tx);
+
+      let sortOrder = payload.sortOrder;
+
+      if (sortOrder == null) {
+        const siblingCount = await tx.category.count({
+          where: { parentId },
+        });
+        sortOrder = siblingCount;
+      }
+
+      const category = await tx.category.create({
+        data: {
+          name: payload.name,
+          slug,
+          parentId,
+          sortOrder,
+          path: "",
+        },
+      });
+
+      const path = await buildCategoryPath(category.id, tx);
+
+      return tx.category.update({
+        where: { id: category.id },
+        data: { path },
+      });
+    });
+
+    return NextResponse.json(createdCategory, { status: 201 });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}


### PR DESCRIPTION
## Summary
- add a persistent `path` column and helper utilities for rebuilding category paths
- implement category CRUD, reorder, and maintenance API routes with validation and slug management

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6fa39e2c48321b8adc450d7af2545