### PR TITLE
Add product CRUD endpoints with search improvements

### DIFF
--- a/lib/validation.product.ts
+++ b/lib/validation.product.ts
@@ -2,7 +2,9 @@ import { z } from "zod";
 
 const nonEmptyString = z.string().trim().min(1, "Required");
 const optionalNonEmptyString = nonEmptyString.optional();
-const imageUrlsSchema = z.array(z.string().trim());
+const imageUrlsSchema = z
+  .array(z.string().trim().url({ message: "Image URL must be a valid URL" }))
+  .optional();
 
 export const createProductSchema = z.object({
   name: nonEmptyString,
@@ -10,7 +12,7 @@ export const createProductSchema = z.object({
   model: optionalNonEmptyString,
   categoryId: optionalNonEmptyString,
   specsJson: z.unknown().optional(),
-  imageUrls: imageUrlsSchema.optional(),
+  imageUrls: imageUrlsSchema,
 });
 
 export type CreateProductDTO = z.infer<typeof createProductSchema>;
@@ -21,7 +23,7 @@ export const updateProductSchema = z.object({
   model: optionalNonEmptyString,
   categoryId: optionalNonEmptyString,
   specsJson: z.unknown().optional(),
-  imageUrls: imageUrlsSchema.optional(),
+  imageUrls: imageUrlsSchema,
 });
 
 export type UpdateProductDTO = z.infer<typeof updateProductSchema>;

--- a/src/app/api/products/[id]/route.ts
+++ b/src/app/api/products/[id]/route.ts
@@ -1,0 +1,105 @@
+import type { Prisma } from "@prisma/client";
+import { NextResponse } from "next/server";
+
+import { prisma } from "../../../../../lib/prisma";
+import { updateProductSchema } from "../../../../../lib/validation.product";
+import { BadRequestError, NotFoundError, handleApiError, parseJsonBody } from "../_utils";
+
+export async function GET(_: Request, { params }: { params: { id: string } }) {
+  try {
+    const product = await prisma.product.findUnique({
+      where: { id: params.id },
+      include: {
+        category: { select: { id: true, name: true, slug: true } },
+        _count: { select: { items: true } },
+      },
+    });
+
+    if (!product) {
+      throw new NotFoundError("Product not found");
+    }
+
+    const soldItems = await prisma.item.findMany({
+      where: { productId: params.id, soldAt: { not: null } },
+      select: { id: true, soldAt: true, soldPriceToman: true },
+      orderBy: { soldAt: "desc" },
+      take: 10,
+    });
+
+    return NextResponse.json({ ...product, soldItems });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}
+
+export async function PATCH(request: Request, { params }: { params: { id: string } }) {
+  try {
+    const payload = await parseJsonBody(request, updateProductSchema);
+
+    if (Object.keys(payload).length === 0) {
+      throw new BadRequestError("Request body cannot be empty");
+    }
+
+    const data: Prisma.ProductUpdateInput = {};
+
+    if (payload.name !== undefined) {
+      data.name = payload.name;
+    }
+
+    if (payload.brand !== undefined) {
+      data.brand = payload.brand ?? null;
+    }
+
+    if (payload.model !== undefined) {
+      data.model = payload.model ?? null;
+    }
+
+    if (payload.categoryId !== undefined) {
+      data.categoryId = payload.categoryId ?? null;
+    }
+
+    if (payload.specsJson !== undefined) {
+      data.specsJson = payload.specsJson as Prisma.JsonValue;
+    }
+
+    if (payload.imageUrls !== undefined) {
+      data.imageUrls = payload.imageUrls;
+    }
+
+    const product = await prisma.product.update({
+      where: { id: params.id },
+      data,
+      include: {
+        category: { select: { id: true, name: true, slug: true } },
+        _count: { select: { items: true } },
+      },
+    });
+
+    return NextResponse.json(product);
+  } catch (error) {
+    return handleApiError(error);
+  }
+}
+
+export async function DELETE(_: Request, { params }: { params: { id: string } }) {
+  try {
+    const product = await prisma.product.findUnique({
+      where: { id: params.id },
+      select: { id: true, _count: { select: { items: true } } },
+    });
+
+    if (!product) {
+      throw new NotFoundError("Product not found");
+    }
+
+    if (product._count.items > 0) {
+      throw new BadRequestError("Cannot delete a product that still has inventory items");
+    }
+
+    await prisma.product.delete({ where: { id: params.id } });
+
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/src/app/api/products/_utils.ts
+++ b/src/app/api/products/_utils.ts
@@ -1,0 +1,62 @@
+import { Prisma } from "@prisma/client";
+import { NextResponse } from "next/server";
+import type { ZodSchema } from "zod";
+
+export class ApiError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+  }
+}
+
+export class BadRequestError extends ApiError {
+  constructor(message: string) {
+    super(400, message);
+  }
+}
+
+export class NotFoundError extends ApiError {
+  constructor(message: string) {
+    super(404, message);
+  }
+}
+
+export async function parseJsonBody<T>(request: Request, schema: ZodSchema<T>): Promise<T> {
+  let payload: unknown;
+
+  try {
+    payload = await request.json();
+  } catch {
+    throw new BadRequestError("Invalid JSON body");
+  }
+
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new BadRequestError("Request body must be a JSON object");
+  }
+
+  const parsed = schema.safeParse(payload);
+
+  if (!parsed.success) {
+    const message = parsed.error.errors.map((err) => err.message).join(", ");
+    throw new BadRequestError(message);
+  }
+
+  return parsed.data;
+}
+
+export function handleApiError(error: unknown) {
+  if (error instanceof ApiError) {
+    return NextResponse.json({ message: error.message }, { status: error.status });
+  }
+
+  if (error instanceof Prisma.PrismaClientKnownRequestError) {
+    if (error.code === "P2025") {
+      return NextResponse.json({ message: "Product not found" }, { status: 404 });
+    }
+  }
+
+  console.error(error);
+  return NextResponse.json({ message: "Internal server error" }, { status: 500 });
+}

--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -1,0 +1,108 @@
+import type { Prisma } from "@prisma/client";
+import { NextResponse } from "next/server";
+
+import { prisma } from "../../../../lib/prisma";
+import { createProductSchema } from "../../../../lib/validation.product";
+
+import { BadRequestError, handleApiError, parseJsonBody } from "./_utils";
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_PAGE_SIZE = 20;
+const MAX_PAGE_SIZE = 100;
+
+function parsePositiveInt(value: string | null, fallback: number): number {
+  if (!value) {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    throw new BadRequestError("Pagination parameters must be positive integers");
+  }
+
+  return parsed;
+}
+
+function buildProductFilters(searchParams: URLSearchParams) {
+  const filters: Prisma.ProductWhereInput = {};
+  const query = searchParams.get("q")?.trim();
+  const categoryId = searchParams.get("categoryId")?.trim();
+  const brand = searchParams.get("brand")?.trim();
+
+  if (query) {
+    filters.OR = [
+      { name: { contains: query, mode: "insensitive" } },
+      { brand: { contains: query, mode: "insensitive" } },
+      { model: { contains: query, mode: "insensitive" } },
+    ];
+  }
+
+  if (categoryId) {
+    filters.categoryId = categoryId;
+  }
+
+  if (brand) {
+    filters.brand = { equals: brand, mode: "insensitive" };
+  }
+
+  return filters;
+}
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const page = parsePositiveInt(searchParams.get("page"), DEFAULT_PAGE);
+    const requestedPageSize = parsePositiveInt(searchParams.get("pageSize"), DEFAULT_PAGE_SIZE);
+    const pageSize = Math.min(requestedPageSize, MAX_PAGE_SIZE);
+    const skip = (page - 1) * pageSize;
+    const where = buildProductFilters(searchParams);
+
+    const [total, items] = await Promise.all([
+      prisma.product.count({ where }),
+      prisma.product.findMany({
+        where,
+        include: {
+          category: { select: { id: true, name: true, slug: true } },
+          _count: { select: { items: true } },
+        },
+        orderBy: { createdAt: "desc" },
+        skip,
+        take: pageSize,
+      }),
+    ]);
+
+    return NextResponse.json({ items, total, page, pageSize });
+  } catch (error) {
+    if (error instanceof BadRequestError) {
+      return NextResponse.json({ message: error.message }, { status: error.status });
+    }
+
+    return handleApiError(error);
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const payload = await parseJsonBody(request, createProductSchema);
+
+    const product = await prisma.product.create({
+      data: {
+        name: payload.name,
+        brand: payload.brand ?? null,
+        model: payload.model ?? null,
+        categoryId: payload.categoryId ?? null,
+        specsJson: payload.specsJson as Prisma.JsonValue | undefined,
+        imageUrls: payload.imageUrls ?? [],
+      },
+      include: {
+        category: { select: { id: true, name: true, slug: true } },
+        _count: { select: { items: true } },
+      },
+    });
+
+    return NextResponse.json(product, { status: 201 });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/src/app/api/products/search/route.ts
+++ b/src/app/api/products/search/route.ts
@@ -1,19 +1,18 @@
 import { NextResponse } from 'next/server';
 
-import { searchProducts } from '../../../../../lib/products';
+import { searchProducts } from "../../../../../lib/products";
 
+const MAX_RESULTS = 10;
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
-  const query = searchParams.get('query') ?? searchParams.get('search') ?? undefined;
-  const takeParam = searchParams.get('take');
-  const take = takeParam ? Number.parseInt(takeParam, 10) : 10;
+  const query = searchParams.get("q")?.trim();
 
-  if (Number.isNaN(take) || take <= 0) {
-    return NextResponse.json({ message: 'Invalid take parameter' }, { status: 400 });
+  if (!query) {
+    return NextResponse.json({ items: [] });
   }
 
-  const products = await searchProducts({ query: query?.trim() || undefined, take: Math.min(take, 25) });
+  const items = await searchProducts({ query, take: MAX_RESULTS });
 
-  return NextResponse.json({ products });
+  return NextResponse.json({ items });
 }


### PR DESCRIPTION
## Summary
- implement /api/products listing with filtering, pagination, and product creation validation
- add /api/products/[id] handlers for fetching, updating, and safe deletion with shared error handling utilities
- tighten product validation and adjust search endpoint for lightweight autocomplete responses

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d70eddc2ec8321b21764e8827cb033