### PR TITLE
feat: allow quick add items to create products

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -147,7 +147,12 @@
     "cancel": "Cancel",
     "clearSelection": "Clear selection",
     "noProducts": "No products matched. Add a product to continue.",
-    "searchPlaceholder": "Search product, model or serial"
+    "searchPlaceholder": "Search product, model or serial",
+    "createProduct": {
+      "trigger": "New product",
+      "title": "Create product",
+      "subtitle": "Add a product without leaving this form."
+    }
   },
   "categories": {
     "title": "Category manager",
@@ -225,7 +230,8 @@
     "details": "Item details",
     "saleChannel": "Sale channel",
     "soldPrice": "Sold price",
-    "acquired": "Acquired"
+    "acquired": "Acquired",
+    "openProduct": "Open product"
   },
   "saleNew": {
     "title": "New sale",

--- a/messages/fa.json
+++ b/messages/fa.json
@@ -148,7 +148,12 @@
     "cancel": "انصراف",
     "clearSelection": "پاک کردن انتخاب",
     "noProducts": "هیچ محصولی یافت نشد. ابتدا یک محصول اضافه کنید.",
-    "searchPlaceholder": "جستجوی محصول، مدل یا سریال"
+    "searchPlaceholder": "جستجوی محصول، مدل یا سریال",
+    "createProduct": {
+      "trigger": "محصول جدید",
+      "title": "ایجاد محصول",
+      "subtitle": "بدون ترک این فرم یک محصول بسازید."
+    }
   },
   "categories": {
     "title": "مدیریت دسته‌بندی‌ها",
@@ -226,7 +231,8 @@
     "details": "جزئیات کالا",
     "saleChannel": "کانال فروش",
     "soldPrice": "قیمت فروش",
-    "acquired": "تاریخ دریافت"
+    "acquired": "تاریخ دریافت",
+    "openProduct": "مشاهده محصول"
   },
   "saleNew": {
     "title": "ثبت فروش جدید",

--- a/src/app/[locale]/items/[id]/page.tsx
+++ b/src/app/[locale]/items/[id]/page.tsx
@@ -93,6 +93,13 @@ export default async function ItemDetailPage({ params }: ItemDetailPageProps) {
                   {item.product.category ? (
                     <p className="text-xs text-[var(--muted)]">{item.product.category.name}</p>
                   ) : null}
+
+                  <Link
+                    href={`/${typedLocale}/products/${item.product.id}`}
+                    className="mt-3 inline-flex items-center text-xs font-medium text-[var(--accent)] transition hover:text-[var(--accent-hover)]"
+                  >
+                    {t('openProduct')}
+                  </Link>
                 </div>
 
                 <div className="grid gap-3 sm:grid-cols-2">

--- a/src/components/product/ProductDetailTabs.tsx
+++ b/src/components/product/ProductDetailTabs.tsx
@@ -78,6 +78,7 @@ export default function ProductDetailTabs({ product, items, soldItems, locale }:
           </thead>
           <tbody className="divide-y divide-[var(--border)]">
             {items.map((item) => {
+              const itemHref = `/${locale}/items/${item.id}`;
               const costValue = totalCost({
                 purchaseToman: item.purchaseToman,
                 feesToman: item.feesToman,
@@ -85,29 +86,47 @@ export default function ProductDetailTabs({ product, items, soldItems, locale }:
               });
               return (
                 <tr key={item.id} className="hover:bg-[var(--surface-muted)]">
-                  <td className="px-4 py-3 text-[var(--foreground)]">{item.serial}</td>
-                  <td className="px-4 py-3 text-[var(--foreground)]">{tConditions(item.condition)}</td>
-                  <td className="px-4 py-3 text-[var(--foreground)]">{tStatuses(item.status)}</td>
                   <td className="px-4 py-3 text-[var(--foreground)]">
-                    <Toman value={costValue} locale={intlLocale} />
+                    <Link href={itemHref} className="block w-full">
+                      {item.serial}
+                    </Link>
                   </td>
                   <td className="px-4 py-3 text-[var(--foreground)]">
-                    {item.listedPriceToman != null ? (
-                      <Toman value={item.listedPriceToman} locale={intlLocale} />
-                    ) : (
-                      <span className="text-xs text-[var(--muted)]">{tDetail("notListed")}</span>
-                    )}
+                    <Link href={itemHref} className="block w-full">
+                      {tConditions(item.condition)}
+                    </Link>
                   </td>
                   <td className="px-4 py-3 text-[var(--foreground)]">
-                    {item.soldPriceToman != null ? (
-                      <Toman value={item.soldPriceToman} locale={intlLocale} />
-                    ) : (
-                      <span className="text-xs text-[var(--muted)]">{tDetail("notSold")}</span>
-                    )}
+                    <Link href={itemHref} className="block w-full">
+                      {tStatuses(item.status)}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 text-[var(--foreground)]">
+                    <Link href={itemHref} className="block w-full">
+                      <Toman value={costValue} locale={intlLocale} />
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 text-[var(--foreground)]">
+                    <Link href={itemHref} className="block w-full">
+                      {item.listedPriceToman != null ? (
+                        <Toman value={item.listedPriceToman} locale={intlLocale} />
+                      ) : (
+                        <span className="text-xs text-[var(--muted)]">{tDetail("notListed")}</span>
+                      )}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 text-[var(--foreground)]">
+                    <Link href={itemHref} className="block w-full">
+                      {item.soldPriceToman != null ? (
+                        <Toman value={item.soldPriceToman} locale={intlLocale} />
+                      ) : (
+                        <span className="text-xs text-[var(--muted)]">{tDetail("notSold")}</span>
+                      )}
+                    </Link>
                   </td>
                   <td className="px-4 py-3 text-right">
                     <Link
-                      href={`/${locale}/items/${item.id}`}
+                      href={itemHref}
                       className="inline-flex items-center gap-2 text-xs font-medium text-[var(--accent)] transition hover:text-[var(--accent-hover)]"
                     >
                       {tDetail("viewItem")}


### PR DESCRIPTION
## Summary
- add inline new-product sheet to the quick add item flow and auto-select the created product
- expose product navigation links from item detail and product detail pages
- update locale strings for the new quick create experience

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7179dff788321b8c4f8d6a1450f7b