### PR TITLE
Add localized deletion guards and inventory counter badges

### DIFF
--- a/lib/api-locale.ts
+++ b/lib/api-locale.ts
@@ -1,0 +1,81 @@
+import { routing, type AppLocale } from "../i18n/routing";
+
+function matchLocale(candidate: string | null | undefined): AppLocale | null {
+  if (!candidate) {
+    return null;
+  }
+
+  const trimmed = candidate.trim().toLowerCase();
+
+  if (!trimmed) {
+    return null;
+  }
+
+  const locales = routing.locales as readonly string[];
+
+  if ((locales as readonly string[]).includes(trimmed)) {
+    return trimmed as AppLocale;
+  }
+
+  const base = trimmed.split("-")[0];
+
+  if ((locales as readonly string[]).includes(base)) {
+    return base as AppLocale;
+  }
+
+  return null;
+}
+
+function localeFromCookie(header: string | null): AppLocale | null {
+  if (!header) {
+    return null;
+  }
+
+  const cookies = header.split(";");
+
+  for (const cookie of cookies) {
+    const [rawName, ...rawValueParts] = cookie.split("=");
+    const name = rawName?.trim();
+
+    if (name?.toUpperCase() !== "NEXT_LOCALE") {
+      continue;
+    }
+
+    const value = rawValueParts.join("=");
+    const decoded = value ? decodeURIComponent(value) : value;
+    const matched = matchLocale(decoded);
+
+    if (matched) {
+      return matched;
+    }
+  }
+
+  return null;
+}
+
+function localeFromAcceptLanguage(header: string | null): AppLocale | null {
+  if (!header) {
+    return null;
+  }
+
+  const parts = header.split(",");
+
+  for (const part of parts) {
+    const [language] = part.split(";");
+    const matched = matchLocale(language);
+
+    if (matched) {
+      return matched;
+    }
+  }
+
+  return null;
+}
+
+export function resolveRequestLocale(request: Request): AppLocale {
+  return (
+    localeFromCookie(request.headers.get("cookie")) ??
+    localeFromAcceptLanguage(request.headers.get("accept-language")) ??
+    routing.defaultLocale
+  );
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -128,6 +128,9 @@
       "notListed": "Not listed",
       "notSold": "Not sold",
       "viewItem": "View item"
+    },
+    "delete": {
+      "hasItems": "Remove all inventory items for this product before deleting it."
     }
   },
   "quickAdd": {
@@ -191,6 +194,9 @@
       "confirm": "Delete",
       "disabledChildren": "Remove subcategories before deleting this category.",
       "disabledProducts": "{count, plural, one {Remove the product assigned to this category first.} other {Remove the # products assigned to this category first.}}"
+    },
+    "badges": {
+      "products": "{count, plural, one {# product} other {# products}}"
     }
   },
   "filters": {

--- a/messages/fa.json
+++ b/messages/fa.json
@@ -129,6 +129,9 @@
       "notListed": "ثبت نشده",
       "notSold": "فروخته نشده",
       "viewItem": "مشاهده کالا"
+    },
+    "delete": {
+      "hasItems": "ابتدا تمام کالاهای این محصول را حذف کنید."
     }
   },
   "quickAdd": {
@@ -192,6 +195,9 @@
       "confirm": "حذف",
       "disabledChildren": "ابتدا زیرمجموعه‌های این دسته‌بندی را حذف کنید.",
       "disabledProducts": "{count, plural, one {ابتدا محصول منتسب به این دسته‌بندی را حذف کنید.} other {ابتدا {count} محصول منتسب به این دسته‌بندی را حذف کنید.}}"
+    },
+    "badges": {
+      "products": "{count, plural, one {# محصول} other {# محصول}}"
     }
   },
   "filters": {

--- a/src/components/category/CategoryTree.tsx
+++ b/src/components/category/CategoryTree.tsx
@@ -2,7 +2,7 @@
 
 import { GripVertical, Loader2, Pencil, Plus, ArrowUpRight, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { useCallback, useMemo, useState } from "react";
 import { toast } from "sonner";
 
@@ -29,6 +29,7 @@ export default function CategoryTree({ categories }: CategoryTreeProps) {
   const router = useRouter();
   const t = useTranslations("categories");
   const tButtons = useTranslations("buttons");
+  const locale = useLocale();
   const [deletingId, setDeletingId] = useState<string | null>(null);
 
   const allCategories = useMemo(() => categories, [categories]);
@@ -39,6 +40,9 @@ export default function CategoryTree({ categories }: CategoryTreeProps) {
         setDeletingId(category.id);
         const response = await fetch(`/api/categories/${category.id}`, {
           method: "DELETE",
+          headers: {
+            "Accept-Language": locale,
+          },
         });
 
         if (!response.ok) {
@@ -58,7 +62,7 @@ export default function CategoryTree({ categories }: CategoryTreeProps) {
         setDeletingId(null);
       }
     },
-    [router, t]
+    [locale, router, t]
   );
 
   function renderNodes(nodes: CategoryTreeNode[], depth = 0) {
@@ -86,8 +90,13 @@ export default function CategoryTree({ categories }: CategoryTreeProps) {
                   <div className="flex flex-1 items-start gap-3">
                     <GripVertical className="mt-1 size-4 text-[var(--muted)]" aria-hidden />
                     <div className="min-w-0 space-y-2">
-                      <div className="break-words text-base font-semibold text-[var(--foreground)]">
-                        {node.name}
+                      <div className="flex flex-wrap items-center gap-2">
+                        <div className="break-words text-base font-semibold text-[var(--foreground)]">
+                          {node.name}
+                        </div>
+                        <span className="inline-flex items-center rounded-full bg-[var(--surface-muted)] px-2 py-0.5 text-xs font-medium text-[var(--muted-strong)]">
+                          {t("badges.products", { count: node.productCount })}
+                        </span>
                       </div>
                       <div className="flex flex-wrap items-center gap-2 text-xs text-[var(--muted)]">
                         <span className="font-medium text-[var(--muted-strong)]">

--- a/src/components/product/ProductForm.tsx
+++ b/src/components/product/ProductForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { useState } from "react";
 import { toast } from "sonner";
 
@@ -47,6 +47,7 @@ function serializeSpecs(value: unknown): string {
 export default function ProductForm({ mode, productId, initialValues, redirectTo }: ProductFormProps) {
   const router = useRouter();
   const t = useTranslations("products.form");
+  const locale = useLocale();
   const [name, setName] = useState(() => initialValues?.name ?? "");
   const [brand, setBrand] = useState(() => initialValues?.brand ?? "");
   const [model, setModel] = useState(() => initialValues?.model ?? "");
@@ -107,7 +108,7 @@ export default function ProductForm({ mode, productId, initialValues, redirectTo
     try {
       const response = await fetch(endpoint, {
         method,
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", "Accept-Language": locale },
         body: JSON.stringify(payload),
       });
 

--- a/src/components/product/ProductsTable.tsx
+++ b/src/components/product/ProductsTable.tsx
@@ -61,7 +61,9 @@ export default function ProductsTable({ products, locale }: ProductsTableProps) 
                 </td>
                 <td className="px-4 py-3 text-[var(--foreground)]">{categoryPath}</td>
                 <td className="px-4 py-3 text-[var(--foreground)]">
-                  {product.itemsCount.toLocaleString(intlLocale)}
+                  <span className="inline-flex min-w-[2.5rem] items-center justify-center rounded-full bg-[var(--surface-muted)] px-2 py-0.5 text-xs font-semibold text-[var(--muted-strong)]">
+                    {product.itemsCount.toLocaleString(intlLocale)}
+                  </span>
                 </td>
                 <td className="px-4 py-3 text-[var(--foreground)]">
                   {dateFormatter.format(new Date(product.createdAt))}


### PR DESCRIPTION
## Summary
- add a shared request-locale resolver and use it to localize category and product deletion guards
- extend UI translations and surface product counts as badges in category tree and product list
- ensure client requests forward the current locale so API errors are shown in the correct language

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d71f53861c8321adcbc518428506ed