### PR TITLE
Add advanced analytics queries and tests

### DIFF
--- a/__tests__/analytics.test.ts
+++ b/__tests__/analytics.test.ts
@@ -1,0 +1,650 @@
+import { Channel, ItemStatus } from '@prisma/client';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  getAgingHistogram,
+  getChannelMix,
+  getInventoryBreakdown,
+  getListingFunnel,
+  getPriceVsMarginSample,
+  getRepairRoi,
+  getRollingAverages,
+  getSellThrough,
+  getTopProductsByProfit,
+} from '../lib/analytics';
+import { prisma } from '../lib/prisma';
+
+const TEST_NOW = new Date('2024-10-01T00:00:00.000Z');
+const dayInMs = 24 * 60 * 60 * 1000;
+const daysAgo = (days: number) => new Date(TEST_NOW.getTime() - days * dayInMs);
+
+type CategoryRecord = { id: string; name: string };
+type ProductRecord = { id: string; name: string; categoryId: string | null };
+type ItemRecord = {
+  id: string;
+  productId: string;
+  status: ItemStatus;
+  purchaseToman: number;
+  feesToman: number;
+  refurbToman: number;
+  acquiredAt: Date;
+  listedAt: Date | null;
+  soldAt: Date | null;
+  soldPriceToman: number | null;
+  saleChannel: Channel | null;
+};
+
+const categories: CategoryRecord[] = [
+  { id: 'cat-laptops', name: 'Laptops Analytics' },
+  { id: 'cat-phones', name: 'Phones Analytics' },
+  { id: 'cat-accessories', name: 'Accessories Analytics' },
+  { id: 'cat-audio', name: 'Audio Analytics' },
+  { id: 'cat-cameras', name: 'Cameras Analytics' },
+  { id: 'cat-gaming', name: 'Gaming Analytics' },
+  { id: 'cat-appliances', name: 'Appliances Analytics' },
+  { id: 'cat-drones', name: 'Drones Analytics' },
+  { id: 'cat-smarthome', name: 'Smart Home Analytics' },
+  { id: 'cat-wearables', name: 'Wearables Analytics' },
+  { id: 'cat-networking', name: 'Networking Analytics' },
+  { id: 'cat-storage', name: 'Storage Analytics' },
+];
+
+const products: ProductRecord[] = [
+  { id: 'prod-laptop', name: 'Laptop Ultra Test', categoryId: 'cat-laptops' },
+  { id: 'prod-phone', name: 'Phone Prime Test', categoryId: 'cat-phones' },
+  { id: 'prod-accessory', name: 'Accessory Elite Test', categoryId: 'cat-accessories' },
+  { id: 'prod-audio', name: 'Audio Product', categoryId: 'cat-audio' },
+  { id: 'prod-cameras', name: 'Cameras Product', categoryId: 'cat-cameras' },
+  { id: 'prod-gaming', name: 'Gaming Product', categoryId: 'cat-gaming' },
+  { id: 'prod-appliances', name: 'Appliances Product', categoryId: 'cat-appliances' },
+  { id: 'prod-drones', name: 'Drones Product', categoryId: 'cat-drones' },
+  { id: 'prod-smarthome', name: 'Smart Home Product', categoryId: 'cat-smarthome' },
+  { id: 'prod-wearables', name: 'Wearables Product', categoryId: 'cat-wearables' },
+  { id: 'prod-networking', name: 'Networking Product', categoryId: 'cat-networking' },
+  { id: 'prod-storage', name: 'Storage Product', categoryId: 'cat-storage' },
+];
+
+const items: ItemRecord[] = [
+  {
+    id: 'item-laptop-stock',
+    productId: 'prod-laptop',
+    status: ItemStatus.IN_STOCK,
+    purchaseToman: 40_000_000,
+    feesToman: 2_000_000,
+    refurbToman: 0,
+    acquiredAt: daysAgo(5),
+    listedAt: null,
+    soldAt: null,
+    soldPriceToman: null,
+    saleChannel: null,
+  },
+  {
+    id: 'item-laptop-listed',
+    productId: 'prod-laptop',
+    status: ItemStatus.LISTED,
+    purchaseToman: 38_000_000,
+    feesToman: 2_000_000,
+    refurbToman: 1_000_000,
+    acquiredAt: daysAgo(35),
+    listedAt: daysAgo(20),
+    soldAt: null,
+    soldPriceToman: null,
+    saleChannel: null,
+  },
+  {
+    id: 'item-laptop-sold-refurb',
+    productId: 'prod-laptop',
+    status: ItemStatus.SOLD,
+    purchaseToman: 40_000_000,
+    feesToman: 5_000_000,
+    refurbToman: 5_000_000,
+    acquiredAt: daysAgo(55),
+    listedAt: daysAgo(15),
+    soldAt: daysAgo(10),
+    soldPriceToman: 70_000_000,
+    saleChannel: Channel.ONLINE,
+  },
+  {
+    id: 'item-laptop-sold-base',
+    productId: 'prod-laptop',
+    status: ItemStatus.SOLD,
+    purchaseToman: 45_000_000,
+    feesToman: 3_000_000,
+    refurbToman: 0,
+    acquiredAt: daysAgo(70),
+    listedAt: daysAgo(50),
+    soldAt: daysAgo(40),
+    soldPriceToman: 65_000_000,
+    saleChannel: Channel.DIRECT,
+  },
+  {
+    id: 'item-phone-stock',
+    productId: 'prod-phone',
+    status: ItemStatus.IN_STOCK,
+    purchaseToman: 19_000_000,
+    feesToman: 1_000_000,
+    refurbToman: 0,
+    acquiredAt: daysAgo(35),
+    listedAt: null,
+    soldAt: null,
+    soldPriceToman: null,
+    saleChannel: null,
+  },
+  {
+    id: 'item-phone-sold-a',
+    productId: 'prod-phone',
+    status: ItemStatus.SOLD,
+    purchaseToman: 18_000_000,
+    feesToman: 2_000_000,
+    refurbToman: 0,
+    acquiredAt: daysAgo(50),
+    listedAt: daysAgo(30),
+    soldAt: daysAgo(15),
+    soldPriceToman: 30_000_000,
+    saleChannel: Channel.DIRECT,
+  },
+  {
+    id: 'item-phone-sold-b',
+    productId: 'prod-phone',
+    status: ItemStatus.SOLD,
+    purchaseToman: 19_000_000,
+    feesToman: 2_000_000,
+    refurbToman: 0,
+    acquiredAt: daysAgo(60),
+    listedAt: daysAgo(35),
+    soldAt: daysAgo(25),
+    soldPriceToman: 32_000_000,
+    saleChannel: Channel.ONLINE,
+  },
+  {
+    id: 'item-accessory-listed',
+    productId: 'prod-accessory',
+    status: ItemStatus.LISTED,
+    purchaseToman: 4_500_000,
+    feesToman: 500_000,
+    refurbToman: 0,
+    acquiredAt: daysAgo(60),
+    listedAt: daysAgo(50),
+    soldAt: null,
+    soldPriceToman: null,
+    saleChannel: null,
+  },
+  {
+    id: 'item-accessory-stock',
+    productId: 'prod-accessory',
+    status: ItemStatus.IN_STOCK,
+    purchaseToman: 3_000_000,
+    feesToman: 200_000,
+    refurbToman: 0,
+    acquiredAt: daysAgo(120),
+    listedAt: null,
+    soldAt: null,
+    soldPriceToman: null,
+    saleChannel: null,
+  },
+  {
+    id: 'item-accessory-sold-refurb',
+    productId: 'prod-accessory',
+    status: ItemStatus.SOLD,
+    purchaseToman: 6_000_000,
+    feesToman: 1_000_000,
+    refurbToman: 1_000_000,
+    acquiredAt: daysAgo(45),
+    listedAt: daysAgo(20),
+    soldAt: daysAgo(5),
+    soldPriceToman: 12_000_000,
+    saleChannel: Channel.OTHER,
+  },
+  {
+    id: 'item-accessory-sold-base',
+    productId: 'prod-accessory',
+    status: ItemStatus.SOLD,
+    purchaseToman: 6_000_000,
+    feesToman: 1_000_000,
+    refurbToman: 0,
+    acquiredAt: daysAgo(80),
+    listedAt: daysAgo(60),
+    soldAt: daysAgo(55),
+    soldPriceToman: 10_000_000,
+    saleChannel: Channel.ONLINE,
+  },
+  {
+    id: 'item-audio-stock',
+    productId: 'prod-audio',
+    status: ItemStatus.IN_STOCK,
+    purchaseToman: 5_000_000,
+    feesToman: 0,
+    refurbToman: 0,
+    acquiredAt: daysAgo(250),
+    listedAt: null,
+    soldAt: null,
+    soldPriceToman: null,
+    saleChannel: null,
+  },
+  {
+    id: 'item-cameras-reserved',
+    productId: 'prod-cameras',
+    status: ItemStatus.RESERVED,
+    purchaseToman: 2_000_000,
+    feesToman: 200_000,
+    refurbToman: 0,
+    acquiredAt: daysAgo(80),
+    listedAt: null,
+    soldAt: null,
+    soldPriceToman: null,
+    saleChannel: null,
+  },
+  {
+    id: 'item-gaming-listed',
+    productId: 'prod-gaming',
+    status: ItemStatus.LISTED,
+    purchaseToman: 3_000_000,
+    feesToman: 150_000,
+    refurbToman: 0,
+    acquiredAt: daysAgo(20),
+    listedAt: daysAgo(18),
+    soldAt: null,
+    soldPriceToman: null,
+    saleChannel: null,
+  },
+  {
+    id: 'item-appliances-reserved',
+    productId: 'prod-appliances',
+    status: ItemStatus.RESERVED,
+    purchaseToman: 2_500_000,
+    feesToman: 100_000,
+    refurbToman: 0,
+    acquiredAt: daysAgo(45),
+    listedAt: null,
+    soldAt: null,
+    soldPriceToman: null,
+    saleChannel: null,
+  },
+  {
+    id: 'item-drones-stock',
+    productId: 'prod-drones',
+    status: ItemStatus.IN_STOCK,
+    purchaseToman: 3_200_000,
+    feesToman: 100_000,
+    refurbToman: 0,
+    acquiredAt: daysAgo(100),
+    listedAt: null,
+    soldAt: null,
+    soldPriceToman: null,
+    saleChannel: null,
+  },
+  {
+    id: 'item-smarthome-stock',
+    productId: 'prod-smarthome',
+    status: ItemStatus.IN_STOCK,
+    purchaseToman: 3_500_000,
+    feesToman: 120_000,
+    refurbToman: 0,
+    acquiredAt: daysAgo(140),
+    listedAt: null,
+    soldAt: null,
+    soldPriceToman: null,
+    saleChannel: null,
+  },
+  {
+    id: 'item-wearables-stock',
+    productId: 'prod-wearables',
+    status: ItemStatus.IN_STOCK,
+    purchaseToman: 3_800_000,
+    feesToman: 150_000,
+    refurbToman: 0,
+    acquiredAt: daysAgo(200),
+    listedAt: null,
+    soldAt: null,
+    soldPriceToman: null,
+    saleChannel: null,
+  },
+  {
+    id: 'item-networking-stock',
+    productId: 'prod-networking',
+    status: ItemStatus.IN_STOCK,
+    purchaseToman: 4_200_000,
+    feesToman: 100_000,
+    refurbToman: 0,
+    acquiredAt: daysAgo(15),
+    listedAt: null,
+    soldAt: null,
+    soldPriceToman: null,
+    saleChannel: null,
+  },
+  {
+    id: 'item-storage-stock',
+    productId: 'prod-storage',
+    status: ItemStatus.IN_STOCK,
+    purchaseToman: 4_500_000,
+    feesToman: 150_000,
+    refurbToman: 0,
+    acquiredAt: daysAgo(25),
+    listedAt: null,
+    soldAt: null,
+    soldPriceToman: null,
+    saleChannel: null,
+  },
+];
+
+const categoryById = new Map(categories.map((category) => [category.id, category]));
+const productById = new Map(products.map((product) => [product.id, product]));
+
+type WhereInput = Parameters<typeof prisma.item.findMany>[0] extends { where: infer W } ? W : never;
+
+function matchesWhereClause(item: ItemRecord, where?: WhereInput): boolean {
+  if (!where) {
+    return true;
+  }
+
+  if (where.status) {
+    if (typeof where.status === 'string') {
+      if (item.status !== where.status) {
+        return false;
+      }
+    } else if (Array.isArray(where.status.in)) {
+      if (!where.status.in.includes(item.status)) {
+        return false;
+      }
+    }
+  }
+
+  if (where.soldAt) {
+    const soldAt = item.soldAt;
+    if (where.soldAt.not !== undefined) {
+      if (where.soldAt.not === null && soldAt == null) {
+        return false;
+      }
+      if (where.soldAt.not !== null && soldAt === where.soldAt.not) {
+        return false;
+      }
+    }
+    if (where.soldAt.gte && (!soldAt || soldAt < where.soldAt.gte)) {
+      return false;
+    }
+    if (where.soldAt.lte && (!soldAt || soldAt > where.soldAt.lte)) {
+      return false;
+    }
+  }
+
+  if (where.listedAt) {
+    const listedAt = item.listedAt;
+    if (where.listedAt.not !== undefined) {
+      if (where.listedAt.not === null && listedAt == null) {
+        return false;
+      }
+    }
+    if (where.listedAt.gte && (!listedAt || listedAt < where.listedAt.gte)) {
+      return false;
+    }
+    if (where.listedAt.lte && (!listedAt || listedAt > where.listedAt.lte)) {
+      return false;
+    }
+  }
+
+  if (where.soldPriceToman) {
+    const soldPrice = item.soldPriceToman;
+    if (where.soldPriceToman.not !== undefined) {
+      if (where.soldPriceToman.not === null && soldPrice == null) {
+        return false;
+      }
+      if (where.soldPriceToman.not !== null && soldPrice === where.soldPriceToman.not) {
+        return false;
+      }
+    }
+  }
+
+  if (where.acquiredAt) {
+    if (where.acquiredAt.gte && item.acquiredAt < where.acquiredAt.gte) {
+      return false;
+    }
+    if (where.acquiredAt.lte && item.acquiredAt > where.acquiredAt.lte) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function buildProductSelection(productId: string, select: Record<string, unknown>): unknown {
+  const product = productById.get(productId);
+  if (!product) {
+    return null;
+  }
+  const category = product.categoryId ? categoryById.get(product.categoryId) ?? null : null;
+  const result: Record<string, unknown> = {};
+  for (const key of Object.keys(select)) {
+    if (key === 'categoryId') {
+      result.categoryId = product.categoryId ?? null;
+    } else if (key === 'name') {
+      result.name = product.name;
+    } else if (key === 'category') {
+      const value = select.category;
+      if (value === true) {
+        result.category = category;
+      } else if (value && typeof value === 'object' && 'select' in value) {
+        const categorySelect = (value as { select?: Record<string, boolean> }).select ?? {};
+        if (categorySelect.name) {
+          result.category = category ? { name: category.name } : null;
+        }
+      }
+    }
+  }
+  return result;
+}
+
+function selectItemFields(item: ItemRecord, select: Record<string, unknown>): unknown {
+  const result: Record<string, unknown> = {};
+  for (const key of Object.keys(select)) {
+    if (key === 'product') {
+      const value = select.product;
+      if (value === true) {
+        const product = productById.get(item.productId);
+        result.product = product
+          ? {
+              ...product,
+              category: product.categoryId ? categoryById.get(product.categoryId) ?? null : null,
+            }
+          : null;
+      } else if (value && typeof value === 'object' && 'select' in value) {
+        result.product = buildProductSelection(item.productId, (value as { select: Record<string, unknown> }).select);
+      }
+    } else {
+      result[key] = (item as Record<string, unknown>)[key];
+    }
+  }
+  return result;
+}
+
+function setupPrismaMocks() {
+  vi.spyOn(prisma.item, 'findMany').mockImplementation(async (args?: Parameters<typeof prisma.item.findMany>[0]) => {
+    const where = args?.where;
+    let result = items.filter((item) => matchesWhereClause(item, where));
+
+    if (args?.orderBy && 'soldAt' in args.orderBy) {
+      const direction = args.orderBy.soldAt;
+      result = [...result].sort((a, b) => {
+        const left = a.soldAt ? a.soldAt.getTime() : 0;
+        const right = b.soldAt ? b.soldAt.getTime() : 0;
+        return direction === 'desc' ? right - left : left - right;
+      });
+    }
+
+    if (typeof args?.take === 'number') {
+      result = result.slice(0, args.take);
+    }
+
+    if (args?.select) {
+      return result.map((item) => selectItemFields(item, args.select as Record<string, unknown>));
+    }
+
+    return result.map((item) => ({
+      ...item,
+      product: buildProductSelection(item.productId, { categoryId: true, category: { select: { name: true } }, name: true }),
+    }));
+  });
+
+  vi.spyOn(prisma.item, 'groupBy').mockImplementation(async (args: Parameters<typeof prisma.item.groupBy>[0]) => {
+    const filtered = items.filter((item) => matchesWhereClause(item, args.where as WhereInput));
+    const groups = new Map<string, { saleChannel: Channel | null; _count: { _all: number }; _sum: { soldPriceToman: number | null } }>();
+
+    filtered.forEach((item) => {
+      const key = item.saleChannel ?? null;
+      if (key == null && !args.by.includes('saleChannel')) {
+        return;
+      }
+      const mapKey = key ?? 'null';
+      const existing = groups.get(mapKey) ?? {
+        saleChannel: key,
+        _count: { _all: 0 },
+        _sum: { soldPriceToman: 0 },
+      };
+      existing._count._all += 1;
+      if (item.soldPriceToman != null) {
+        existing._sum.soldPriceToman = (existing._sum.soldPriceToman ?? 0) + item.soldPriceToman;
+      }
+      groups.set(mapKey, existing);
+    });
+
+    return Array.from(groups.values());
+  });
+
+  vi.spyOn(prisma.item, 'count').mockImplementation(async (args?: Parameters<typeof prisma.item.count>[0]) => {
+    return items.filter((item) => matchesWhereClause(item, args?.where as WhereInput)).length;
+  });
+}
+
+beforeAll(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(TEST_NOW);
+});
+
+afterAll(() => {
+  vi.useRealTimers();
+});
+
+beforeEach(() => {
+  setupPrismaMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('advanced analytics queries', () => {
+  it('summarises inventory by status and category with other bucket', async () => {
+    const breakdown = await getInventoryBreakdown();
+
+    expect(breakdown.rows.length).toBe(11);
+
+    const laptopsRow = breakdown.rows.find((row) => row.categoryName.includes('Laptops'));
+    expect(laptopsRow?.statuses.IN_STOCK.count).toBe(1);
+    expect(laptopsRow?.statuses.LISTED.count).toBe(1);
+    expect(laptopsRow?.totalCount).toBe(2);
+
+    const otherRow = breakdown.rows[breakdown.rows.length - 1];
+    const otherTotalCount =
+      otherRow.statuses.IN_STOCK.count +
+      otherRow.statuses.LISTED.count +
+      otherRow.statuses.RESERVED.count;
+    expect(otherRow.categoryName).toBe('Other');
+    expect(otherTotalCount).toBe(2);
+
+    expect(breakdown.grandTotals.totalCount).toBeGreaterThan(0);
+  });
+
+  it('computes channel mix with revenue totals', async () => {
+    const mix = await getChannelMix({ from: daysAgo(120), to: TEST_NOW });
+
+    expect(mix).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ channel: Channel.DIRECT, count: 2, revenueT: 95_000_000 }),
+        expect.objectContaining({ channel: Channel.ONLINE, count: 3, revenueT: 112_000_000 }),
+        expect.objectContaining({ channel: Channel.OTHER, count: 1, revenueT: 12_000_000 }),
+      ]),
+    );
+  });
+
+  it('ranks top products by profit with median pricing', async () => {
+    const productsByProfit = await getTopProductsByProfit({ from: daysAgo(120), to: TEST_NOW, limit: 10 });
+    const laptop = productsByProfit.find((product) => product.productName.includes('Laptop Ultra'));
+    const phone = productsByProfit.find((product) => product.productName.includes('Phone Prime'));
+
+    expect(laptop).toMatchObject({
+      unitsSold: 2,
+      totalProfitT: 37_000_000,
+      averageProfitT: 18_500_000,
+      medianSoldPriceT: 67_500_000,
+    });
+    expect(phone).toMatchObject({
+      unitsSold: 2,
+      totalProfitT: 21_000_000,
+      averageProfitT: 10_500_000,
+      medianSoldPriceT: 31_000_000,
+    });
+  });
+
+  it('calculates repair ROI versus non-refurbished peers', async () => {
+    const roi = await getRepairRoi({ from: daysAgo(120), to: TEST_NOW });
+
+    expect(roi).toEqual({
+      refurbCount: 2,
+      totalRefurbCostT: 6_000_000,
+      totalRefurbProfitT: 24_000_000,
+      peerBaselineProfitT: 20_000_000,
+      extraMarginT: 4_000_000,
+      averageExtraMarginPerItemT: 2_000_000,
+    });
+  });
+
+  it('computes sell-through per category', async () => {
+    const sellThrough = await getSellThrough({ from: daysAgo(90), to: TEST_NOW });
+
+    const laptops = sellThrough.find((entry) => entry.categoryName.includes('Laptops'));
+    const phones = sellThrough.find((entry) => entry.categoryName.includes('Phones'));
+    const accessories = sellThrough.find((entry) => entry.categoryName.includes('Accessories'));
+
+    expect(laptops?.sellThroughRate ?? 0).toBeCloseTo(0.5, 5);
+    expect(phones?.sellThroughRate ?? 0).toBeCloseTo(2 / 3, 5);
+    expect(accessories?.sellThroughRate ?? 0).toBeCloseTo(0.5, 5);
+  });
+
+  it('returns aging histogram with 10-day bins', async () => {
+    const histogram = await getAgingHistogram();
+
+    const zeroToNine = histogram.find((bucket) => bucket.label === '0-9');
+    expect(zeroToNine?.count).toBe(1);
+
+    const thirtyToThirtyNine = histogram.find((bucket) => bucket.label === '30-39');
+    expect(thirtyToThirtyNine?.count).toBe(2);
+
+    const overflow = histogram[histogram.length - 1];
+    expect(overflow.label).toBe('240+');
+    expect(overflow.count).toBeGreaterThanOrEqual(1);
+  });
+
+  it('provides price vs margin sampling capped by limit', async () => {
+    const sample = await getPriceVsMarginSample({ limit: 5 });
+    expect(sample).toHaveLength(5);
+    expect(sample[0]).toMatchObject({ soldPriceT: 12_000_000, marginT: 4_000_000 });
+  });
+
+  it('summarises listing funnel for last 90 days', async () => {
+    const funnel = await getListingFunnel();
+
+    expect(funnel.from).toEqual(daysAgo(90));
+    expect(funnel.inStock).toBeGreaterThanOrEqual(4);
+    expect(funnel.listed).toBeGreaterThanOrEqual(3);
+    expect(funnel.sold).toBe(6);
+  });
+
+  it('computes rolling averages for 30 and 60 days', async () => {
+    const rolling = await getRollingAverages();
+
+    expect(rolling.days30.averageDailyProfitT).toBeCloseTo(45_000_000 / 30, 5);
+    expect(rolling.days30.averageDailyUnits).toBeCloseTo(4 / 30, 5);
+    expect(rolling.days60.averageDailyProfitT).toBeCloseTo(65_000_000 / 60, 5);
+    expect(rolling.days60.averageDailyUnits).toBeCloseTo(6 / 60, 5);
+  });
+});
+

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,4 +1,4 @@
-import { ItemStatus } from '@prisma/client';
+import { Channel, ItemStatus } from '@prisma/client';
 import {
   addMonths,
   differenceInCalendarDays,
@@ -16,6 +16,122 @@ const ACTIVE_STATUSES: ItemStatus[] = [
   ItemStatus.LISTED,
   ItemStatus.RESERVED,
 ];
+
+const INVENTORY_STATUS_KEYS = [
+  ItemStatus.IN_STOCK,
+  ItemStatus.LISTED,
+  ItemStatus.RESERVED,
+] as const;
+
+type InventoryStatusKey = (typeof INVENTORY_STATUS_KEYS)[number];
+
+type StatusSummary = { count: number; totalCostT: number };
+
+export type InventoryBreakdownRow = {
+  categoryId: string | null;
+  categoryName: string;
+  statuses: Record<InventoryStatusKey, StatusSummary>;
+  totalCount: number;
+  totalCostT: number;
+};
+
+export type InventoryBreakdown = {
+  rows: InventoryBreakdownRow[];
+  grandTotals: {
+    statuses: Record<InventoryStatusKey, StatusSummary>;
+    totalCount: number;
+    totalCostT: number;
+  };
+};
+
+export type ChannelMixRequest = {
+  from: Date;
+  to: Date;
+};
+
+export type ChannelMixEntry = {
+  channel: Channel | 'UNKNOWN';
+  count: number;
+  revenueT: number;
+};
+
+export type TopProductsByProfitRequest = {
+  from: Date;
+  to: Date;
+  limit?: number;
+};
+
+export type TopProductByProfit = {
+  productId: string;
+  productName: string;
+  unitsSold: number;
+  totalProfitT: number;
+  averageProfitT: number;
+  medianSoldPriceT: number;
+};
+
+export type RepairRoiRequest = {
+  from: Date;
+  to: Date;
+};
+
+export type RepairRoiSummary = {
+  refurbCount: number;
+  totalRefurbCostT: number;
+  totalRefurbProfitT: number;
+  peerBaselineProfitT: number;
+  extraMarginT: number;
+  averageExtraMarginPerItemT: number;
+};
+
+export type SellThroughRequest = {
+  from: Date;
+  to: Date;
+};
+
+export type SellThroughEntry = {
+  categoryId: string | null;
+  categoryName: string;
+  soldUnits: number;
+  endingInventoryUnits: number;
+  sellThroughRate: number;
+};
+
+export type AgingHistogramBucket = {
+  label: string;
+  minDays: number;
+  maxDays: number | null;
+  count: number;
+  totalCostT: number;
+};
+
+export type PriceVsMarginSampleRequest = {
+  limit?: number;
+};
+
+export type PriceVsMarginPoint = {
+  soldPriceT: number;
+  marginT: number;
+  productId: string;
+};
+
+export type ListingFunnelSnapshot = {
+  from: Date;
+  inStock: number;
+  listed: number;
+  sold: number;
+};
+
+export type RollingAverages = {
+  days30: {
+    averageDailyProfitT: number;
+    averageDailyUnits: number;
+  };
+  days60: {
+    averageDailyProfitT: number;
+    averageDailyUnits: number;
+  };
+};
 
 export type AgingBucketKey = '0-30' | '31-90' | '91-180' | '181+';
 
@@ -54,6 +170,601 @@ function computeCost(item: {
   refurbToman: number;
 }): number {
   return (item.purchaseToman ?? 0) + (item.feesToman ?? 0) + (item.refurbToman ?? 0);
+}
+
+function createEmptyStatusSummary(): Record<InventoryStatusKey, StatusSummary> {
+  return INVENTORY_STATUS_KEYS.reduce((acc, status) => {
+    acc[status] = { count: 0, totalCostT: 0 };
+    return acc;
+  }, {} as Record<InventoryStatusKey, StatusSummary>);
+}
+
+export async function getInventoryBreakdown(): Promise<InventoryBreakdown> {
+  const items = await prisma.item.findMany({
+    where: {
+      status: { in: INVENTORY_STATUS_KEYS },
+    },
+    select: {
+      status: true,
+      purchaseToman: true,
+      feesToman: true,
+      refurbToman: true,
+      product: {
+        select: {
+          categoryId: true,
+          category: {
+            select: {
+              name: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const categoryMap = new Map<string, InventoryBreakdownRow>();
+
+  items.forEach((item) => {
+    const status = item.status as InventoryStatusKey;
+    const categoryId = item.product?.categoryId ?? null;
+    const key = categoryId ?? 'uncategorized';
+    const categoryName = item.product?.category?.name ?? 'Uncategorized';
+    const cost = computeCost(item);
+
+    let row = categoryMap.get(key);
+    if (!row) {
+      row = {
+        categoryId,
+        categoryName,
+        statuses: createEmptyStatusSummary(),
+        totalCount: 0,
+        totalCostT: 0,
+      };
+      categoryMap.set(key, row);
+    }
+
+    row.totalCount += 1;
+    row.totalCostT += cost;
+    row.statuses[status].count += 1;
+    row.statuses[status].totalCostT += cost;
+  });
+
+  const sortedRows = Array.from(categoryMap.values()).sort(
+    (a, b) => b.totalCostT - a.totalCostT,
+  );
+
+  const topRows = sortedRows.slice(0, 10);
+  const otherRows = sortedRows.slice(10);
+
+  if (otherRows.length > 0) {
+    const otherRow: InventoryBreakdownRow = {
+      categoryId: null,
+      categoryName: 'Other',
+      statuses: createEmptyStatusSummary(),
+      totalCount: 0,
+      totalCostT: 0,
+    };
+
+    otherRows.forEach((row) => {
+      otherRow.totalCount += row.totalCount;
+      otherRow.totalCostT += row.totalCostT;
+      INVENTORY_STATUS_KEYS.forEach((status) => {
+        otherRow.statuses[status].count += row.statuses[status].count;
+        otherRow.statuses[status].totalCostT += row.statuses[status].totalCostT;
+      });
+    });
+
+    topRows.push(otherRow);
+  }
+
+  const grandTotals = sortedRows.reduce<InventoryBreakdown['grandTotals']>(
+    (totals, row) => {
+      totals.totalCount += row.totalCount;
+      totals.totalCostT += row.totalCostT;
+      INVENTORY_STATUS_KEYS.forEach((status) => {
+        totals.statuses[status].count += row.statuses[status].count;
+        totals.statuses[status].totalCostT += row.statuses[status].totalCostT;
+      });
+      return totals;
+    },
+    {
+      statuses: createEmptyStatusSummary(),
+      totalCount: 0,
+      totalCostT: 0,
+    },
+  );
+
+  return {
+    rows: topRows,
+    grandTotals,
+  };
+}
+
+export async function getChannelMix({ from, to }: ChannelMixRequest): Promise<ChannelMixEntry[]> {
+  const grouped = await prisma.item.groupBy({
+    by: ['saleChannel'],
+    where: {
+      status: ItemStatus.SOLD,
+      soldAt: {
+        gte: from,
+        lte: to,
+      },
+      soldPriceToman: {
+        not: null,
+      },
+    },
+    _count: {
+      _all: true,
+    },
+    _sum: {
+      soldPriceToman: true,
+    },
+  });
+
+  return grouped
+    .map((entry) => ({
+      channel: entry.saleChannel ?? 'UNKNOWN',
+      count: entry._count._all,
+      revenueT: entry._sum.soldPriceToman ?? 0,
+    }))
+    .sort((a, b) => b.revenueT - a.revenueT);
+}
+
+export async function getTopProductsByProfit({
+  from,
+  to,
+  limit = 10,
+}: TopProductsByProfitRequest): Promise<TopProductByProfit[]> {
+  const soldItems = await prisma.item.findMany({
+    where: {
+      status: ItemStatus.SOLD,
+      soldAt: {
+        gte: from,
+        lte: to,
+      },
+      soldPriceToman: {
+        not: null,
+      },
+    },
+    select: {
+      productId: true,
+      soldPriceToman: true,
+      purchaseToman: true,
+      feesToman: true,
+      refurbToman: true,
+      product: {
+        select: {
+          name: true,
+        },
+      },
+    },
+  });
+
+  const productMap = new Map<
+    string,
+    {
+      productName: string;
+      profits: number[];
+      soldPrices: number[];
+    }
+  >();
+
+  soldItems.forEach((item) => {
+    if (item.soldPriceToman == null) {
+      return;
+    }
+    const profit = item.soldPriceToman - computeCost(item);
+    const existing = productMap.get(item.productId);
+    if (existing) {
+      existing.profits.push(profit);
+      existing.soldPrices.push(item.soldPriceToman);
+      return;
+    }
+
+    productMap.set(item.productId, {
+      productName: item.product?.name ?? 'Unknown Product',
+      profits: [profit],
+      soldPrices: [item.soldPriceToman],
+    });
+  });
+
+  const results = Array.from(productMap.entries()).map(([productId, data]) => {
+    const unitsSold = data.profits.length;
+    const totalProfitT = data.profits.reduce((sum, value) => sum + value, 0);
+    const averageProfitT = unitsSold > 0 ? Math.round(totalProfitT / unitsSold) : 0;
+    const sortedPrices = [...data.soldPrices].sort((a, b) => a - b);
+    const mid = Math.floor(sortedPrices.length / 2);
+    let medianSoldPriceT = 0;
+    if (sortedPrices.length > 0) {
+      if (sortedPrices.length % 2 === 0) {
+        medianSoldPriceT = Math.round(
+          (sortedPrices[mid - 1]! + sortedPrices[mid]!) / 2,
+        );
+      } else {
+        medianSoldPriceT = sortedPrices[mid]!;
+      }
+    }
+
+    return {
+      productId,
+      productName: data.productName,
+      unitsSold,
+      totalProfitT,
+      averageProfitT,
+      medianSoldPriceT,
+    } satisfies TopProductByProfit;
+  });
+
+  return results
+    .sort((a, b) => b.totalProfitT - a.totalProfitT)
+    .slice(0, limit);
+}
+
+export async function getRepairRoi({ from, to }: RepairRoiRequest): Promise<RepairRoiSummary> {
+  const soldItems = await prisma.item.findMany({
+    where: {
+      status: ItemStatus.SOLD,
+      soldAt: {
+        gte: from,
+        lte: to,
+      },
+      soldPriceToman: {
+        not: null,
+      },
+    },
+    select: {
+      productId: true,
+      soldPriceToman: true,
+      purchaseToman: true,
+      feesToman: true,
+      refurbToman: true,
+    },
+  });
+
+  const refurbItems: { productId: string; refurbToman: number; profit: number }[] = [];
+  const nonRefurbProfit = new Map<string, { total: number; count: number }>();
+
+  soldItems.forEach((item) => {
+    if (item.soldPriceToman == null) {
+      return;
+    }
+    const profit = item.soldPriceToman - computeCost(item);
+    if (item.refurbToman > 0) {
+      refurbItems.push({
+        productId: item.productId,
+        refurbToman: item.refurbToman,
+        profit,
+      });
+      return;
+    }
+
+    const baseline = nonRefurbProfit.get(item.productId) ?? { total: 0, count: 0 };
+    baseline.total += profit;
+    baseline.count += 1;
+    nonRefurbProfit.set(item.productId, baseline);
+  });
+
+  let totalRefurbCostT = 0;
+  let totalRefurbProfitT = 0;
+  let peerBaselineProfitT = 0;
+
+  refurbItems.forEach((item) => {
+    totalRefurbCostT += item.refurbToman;
+    totalRefurbProfitT += item.profit;
+    const baseline = nonRefurbProfit.get(item.productId);
+    if (baseline && baseline.count > 0) {
+      peerBaselineProfitT += Math.round(baseline.total / baseline.count);
+    }
+  });
+
+  const extraMarginT = totalRefurbProfitT - peerBaselineProfitT;
+  const averageExtraMarginPerItemT =
+    refurbItems.length > 0 ? Math.round(extraMarginT / refurbItems.length) : 0;
+
+  return {
+    refurbCount: refurbItems.length,
+    totalRefurbCostT,
+    totalRefurbProfitT,
+    peerBaselineProfitT,
+    extraMarginT,
+    averageExtraMarginPerItemT,
+  };
+}
+
+export async function getSellThrough({
+  from,
+  to,
+}: SellThroughRequest): Promise<SellThroughEntry[]> {
+  const soldItems = await prisma.item.findMany({
+    where: {
+      status: ItemStatus.SOLD,
+      soldAt: {
+        gte: from,
+        lte: to,
+      },
+      soldPriceToman: {
+        not: null,
+      },
+    },
+    select: {
+      product: {
+        select: {
+          categoryId: true,
+          category: {
+            select: {
+              name: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const inventoryItems = await prisma.item.findMany({
+    where: {
+      status: { in: INVENTORY_STATUS_KEYS },
+      acquiredAt: {
+        lte: to,
+      },
+    },
+    select: {
+      product: {
+        select: {
+          categoryId: true,
+          category: {
+            select: {
+              name: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const categoryTotals = new Map<
+    string,
+    {
+      categoryId: string | null;
+      categoryName: string;
+      soldUnits: number;
+      endingInventoryUnits: number;
+    }
+  >();
+
+  const ensureCategory = (categoryId: string | null, categoryName: string) => {
+    const key = categoryId ?? 'uncategorized';
+    let entry = categoryTotals.get(key);
+    if (!entry) {
+      entry = {
+        categoryId,
+        categoryName,
+        soldUnits: 0,
+        endingInventoryUnits: 0,
+      };
+      categoryTotals.set(key, entry);
+    }
+    return entry;
+  };
+
+  soldItems.forEach((item) => {
+    const categoryId = item.product?.categoryId ?? null;
+    const categoryName = item.product?.category?.name ?? 'Uncategorized';
+    const entry = ensureCategory(categoryId, categoryName);
+    entry.soldUnits += 1;
+  });
+
+  inventoryItems.forEach((item) => {
+    const categoryId = item.product?.categoryId ?? null;
+    const categoryName = item.product?.category?.name ?? 'Uncategorized';
+    const entry = ensureCategory(categoryId, categoryName);
+    entry.endingInventoryUnits += 1;
+  });
+
+  return Array.from(categoryTotals.values())
+    .map((entry) => {
+      const denominator = entry.soldUnits + entry.endingInventoryUnits;
+      const sellThroughRate = denominator > 0 ? entry.soldUnits / denominator : 0;
+      return {
+        ...entry,
+        sellThroughRate,
+      } satisfies SellThroughEntry;
+    })
+    .sort((a, b) => b.sellThroughRate - a.sellThroughRate || b.soldUnits - a.soldUnits);
+}
+
+export async function getAgingHistogram(): Promise<AgingHistogramBucket[]> {
+  const items = await prisma.item.findMany({
+    where: {
+      status: { in: INVENTORY_STATUS_KEYS },
+    },
+    select: {
+      acquiredAt: true,
+      purchaseToman: true,
+      feesToman: true,
+      refurbToman: true,
+    },
+  });
+
+  const now = new Date();
+  const bucketSize = 10;
+  const maxDays = 240;
+  const bucketCount = maxDays / bucketSize;
+
+  const buckets: AgingHistogramBucket[] = Array.from({ length: bucketCount }, (_, index) => {
+    const minDays = index * bucketSize;
+    const maxDaysForBucket = minDays + bucketSize - 1;
+    return {
+      label: `${minDays}-${maxDaysForBucket}`,
+      minDays,
+      maxDays: maxDaysForBucket,
+      count: 0,
+      totalCostT: 0,
+    } satisfies AgingHistogramBucket;
+  });
+
+  const overflowBucket: AgingHistogramBucket = {
+    label: `${maxDays}+`,
+    minDays: maxDays,
+    maxDays: null,
+    count: 0,
+    totalCostT: 0,
+  };
+
+  items.forEach((item) => {
+    const age = Math.max(0, differenceInCalendarDays(now, item.acquiredAt));
+    const cost = computeCost(item);
+    const bucketIndex = Math.min(Math.floor(age / bucketSize), bucketCount);
+    if (bucketIndex >= bucketCount) {
+      overflowBucket.count += 1;
+      overflowBucket.totalCostT += cost;
+      return;
+    }
+
+    const bucket = buckets[bucketIndex]!;
+    bucket.count += 1;
+    bucket.totalCostT += cost;
+  });
+
+  return [...buckets, overflowBucket];
+}
+
+export async function getPriceVsMarginSample({
+  limit = 500,
+}: PriceVsMarginSampleRequest): Promise<PriceVsMarginPoint[]> {
+  const safeLimit = Math.max(1, Math.min(limit, 1000));
+  const soldItems = await prisma.item.findMany({
+    where: {
+      status: ItemStatus.SOLD,
+      soldPriceToman: {
+        not: null,
+      },
+    },
+    orderBy: {
+      soldAt: 'desc',
+    },
+    take: safeLimit,
+    select: {
+      productId: true,
+      soldPriceToman: true,
+      purchaseToman: true,
+      feesToman: true,
+      refurbToman: true,
+    },
+  });
+
+  return soldItems
+    .filter((item) => item.soldPriceToman != null)
+    .map((item) => {
+      const soldPriceT = item.soldPriceToman ?? 0;
+      const marginT = soldPriceT - computeCost(item);
+      return {
+        soldPriceT,
+        marginT,
+        productId: item.productId,
+      } satisfies PriceVsMarginPoint;
+    });
+}
+
+export async function getListingFunnel(): Promise<ListingFunnelSnapshot> {
+  const now = new Date();
+  const windowStart = subDays(now, 90);
+
+  const [inStock, listed, sold] = await Promise.all([
+    prisma.item.count({
+      where: {
+        status: ItemStatus.IN_STOCK,
+        acquiredAt: {
+          gte: windowStart,
+          lte: now,
+        },
+      },
+    }),
+    prisma.item.count({
+      where: {
+        listedAt: {
+          not: null,
+          gte: windowStart,
+          lte: now,
+        },
+      },
+    }),
+    prisma.item.count({
+      where: {
+        status: ItemStatus.SOLD,
+        soldAt: {
+          not: null,
+          gte: windowStart,
+          lte: now,
+        },
+        soldPriceToman: {
+          not: null,
+        },
+      },
+    }),
+  ]);
+
+  return {
+    from: windowStart,
+    inStock,
+    listed,
+    sold,
+  };
+}
+
+export async function getRollingAverages(): Promise<RollingAverages> {
+  const now = new Date();
+  const start60 = subDays(now, 59);
+  const start30 = subDays(now, 29);
+
+  const soldItems = await prisma.item.findMany({
+    where: {
+      status: ItemStatus.SOLD,
+      soldAt: {
+        not: null,
+        gte: start60,
+        lte: now,
+      },
+      soldPriceToman: {
+        not: null,
+      },
+    },
+    select: {
+      soldAt: true,
+      soldPriceToman: true,
+      purchaseToman: true,
+      feesToman: true,
+      refurbToman: true,
+    },
+  });
+
+  const totals60 = { profit: 0, units: 0 };
+  const totals30 = { profit: 0, units: 0 };
+
+  soldItems.forEach((item) => {
+    if (!item.soldAt || item.soldPriceToman == null) {
+      return;
+    }
+
+    const profit = item.soldPriceToman - computeCost(item);
+    totals60.profit += profit;
+    totals60.units += 1;
+
+    if (item.soldAt >= start30) {
+      totals30.profit += profit;
+      totals30.units += 1;
+    }
+  });
+
+  return {
+    days30: {
+      averageDailyProfitT: totals30.profit / 30,
+      averageDailyUnits: totals30.units / 30,
+    },
+    days60: {
+      averageDailyProfitT: totals60.profit / 60,
+      averageDailyUnits: totals60.units / 60,
+    },
+  } satisfies RollingAverages;
 }
 
 export async function getInventoryValue(): Promise<number> {


### PR DESCRIPTION
## Summary
- add typed analytics helpers for inventory breakdown, channel mix, profitability, repair ROI, sell-through, aging, pricing samples, funnels, and rolling metrics
- introduce targeted vitest coverage using mocked Prisma data for the new analytics functions

## Testing
- npx vitest run __tests__/analytics.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d7808d8fbc83219242698a2ddde455