### PR TITLE
Persist report filters in URL and enable drilldowns

### DIFF
--- a/lib/reporting-data.ts
+++ b/lib/reporting-data.ts
@@ -42,10 +42,10 @@ export type ReportFilters = {
 };
 
 export type SerializedFilters = {
-  start: string;
-  end: string;
+  from: string;
+  to: string;
   channels: ReportChannel[];
-  category: string | null;
+  categoryId: string | null;
 };
 
 export type MonthlyFinancial = {
@@ -686,19 +686,19 @@ export function getReportsAggregates(filters: ReportFilters): ReportsAggregates 
 
 export function serializeFilters(filters: ReportFilters): SerializedFilters {
   return {
-    start: formatISO(filters.startDate, { representation: 'date' }),
-    end: formatISO(filters.endDate, { representation: 'date' }),
+    from: formatISO(filters.startDate, { representation: 'date' }),
+    to: formatISO(filters.endDate, { representation: 'date' }),
     channels: filters.channels,
-    category: filters.category,
+    categoryId: filters.category,
   };
 }
 
 export function deserializeFilters(value: SerializedFilters): ReportFilters {
   return {
-    startDate: startOfDay(new Date(value.start)),
-    endDate: endOfDay(new Date(value.end)),
+    startDate: startOfDay(new Date(value.from)),
+    endDate: endOfDay(new Date(value.to)),
     channels: value.channels,
-    category: value.category,
+    category: value.categoryId,
   };
 }
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -329,6 +329,7 @@
       "category": "Category",
       "allCategories": "All categories",
       "apply": "Apply",
+      "reset": "Reset",
       "export": "Export CSV",
       "exportCurrent": "Current view",
       "exportAll": "Full dataset"

--- a/messages/fa.json
+++ b/messages/fa.json
@@ -330,6 +330,7 @@
       "category": "دسته‌بندی",
       "allCategories": "همه دسته‌ها",
       "apply": "اعمال",
+      "reset": "بازنشانی",
       "export": "خروجی CSV",
       "exportCurrent": "نمای فعلی",
       "exportAll": "کل داده‌ها"

--- a/src/app/(dashboard)/reports/page.tsx
+++ b/src/app/(dashboard)/reports/page.tsx
@@ -57,10 +57,10 @@ function buildFilters(
   availableChannels: ReportChannel[],
   categories: string[],
 ): ReportFilters {
-  const start = parseDate(getParam(params.start), defaults.startDate);
-  const end = parseDate(getParam(params.end), defaults.endDate);
-  const channels = parseChannels(params.channel, availableChannels);
-  const category = parseCategory(params.category, categories);
+  const start = parseDate(getParam(params.from), defaults.startDate);
+  const end = parseDate(getParam(params.to), defaults.endDate);
+  const channels = parseChannels(params['channels[]'], availableChannels);
+  const category = parseCategory(params.categoryId, categories);
 
   return {
     startDate: start,
@@ -80,11 +80,18 @@ export default async function ReportsPage({ searchParams }: ReportsPageProps) {
   const filters = buildFilters(resolvedParams, defaults, channels, categories);
   const aggregates = getReportsAggregates(filters);
   const serialized: SerializedFilters = serializeFilters(filters);
+  const serializedDefaults: SerializedFilters = serializeFilters(defaults);
 
   return (
     <div className="space-y-6">
       <PageHeader title={t('title')} description={t('subtitle')} />
-      <ReportsDashboard data={aggregates} filters={serialized} channels={channels} categories={categories} />
+      <ReportsDashboard
+        data={aggregates}
+        filters={serialized}
+        defaultFilters={serializedDefaults}
+        channels={channels}
+        categories={categories}
+      />
     </div>
   );
 }

--- a/src/app/[locale]/items/page.tsx
+++ b/src/app/[locale]/items/page.tsx
@@ -25,8 +25,13 @@ function toArray<T extends string>(value: string | string[] | undefined, validat
     return [];
   }
 
-  const values = Array.isArray(value) ? value : [value];
-  return values.filter((entry): entry is T => validator.has(entry as T));
+  const rawValues = Array.isArray(value) ? value : [value];
+  const normalized = rawValues
+    .flatMap((entry) => entry.split(',').map((part) => part.trim()))
+    .filter((entry) => entry.length > 0);
+
+  const unique = Array.from(new Set(normalized));
+  return unique.filter((entry): entry is T => validator.has(entry as T));
 }
 
 function getPage(searchParams: Record<string, string | string[] | undefined>) {

--- a/src/app/api/reports/export/route.ts
+++ b/src/app/api/reports/export/route.ts
@@ -10,7 +10,7 @@ import {
 
 function parseChannels(params: URLSearchParams, available: ReportChannel[]): ReportChannel[] {
   const allowed = new Set<ReportChannel>(available);
-  const provided = params.getAll('channel') as ReportChannel[];
+  const provided = params.getAll('channels[]') as ReportChannel[];
   const valid = provided.filter((channel) => allowed.has(channel));
   return valid.length > 0 ? valid : available;
 }
@@ -21,9 +21,9 @@ export async function GET(request: Request) {
   const defaults = defaultFilters();
   const { channels: availableChannels } = getAvailableFilters();
 
-  const startParam = params.get('start');
-  const endParam = params.get('end');
-  const categoryParam = params.get('category');
+  const startParam = params.get('from');
+  const endParam = params.get('to');
+  const categoryParam = params.get('categoryId');
 
   const startDate = startParam ? new Date(startParam) : defaults.startDate;
   const endDate = endParam ? new Date(endParam) : defaults.endDate;


### PR DESCRIPTION
## Summary
- persist report dashboard filters in the URL using `from`, `to`, `channels[]`, and `categoryId`
- add a reset option and RTL-friendly date handling to the dashboard filter bar
- wire charts to drill down into items/products pages and update API/export handling for the new parameters

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7a43afa54832197a425e305d6c50d