### PR TITLE
Add configurable settings UI with persistence

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -7,3 +7,4 @@ export * from "./slug";
 export * from "./category-path";
 export * from "./validation.product";
 export * from "./validation.category";
+export * from "./settings";

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -1,0 +1,259 @@
+import { Channel, ItemCondition } from '@prisma/client';
+import { z } from 'zod';
+
+import type { AppLocale } from '../i18n/routing';
+
+import { prisma } from './prisma';
+
+const shouldUseMemoryStore = process.env.APP_SETTINGS_MODE === 'memory' || !process.env.DATABASE_URL;
+const memoryStore = new Map<string, unknown>();
+
+const APP_LOCALES = ['fa', 'en'] as const satisfies readonly AppLocale[];
+
+const rtlPreferenceSchema = z.enum(['auto', 'ltr', 'rtl']);
+
+const generalSettingsSchema = z.object({
+  businessName: z.string().min(1).max(120),
+  defaultChannel: z.nativeEnum(Channel),
+  defaultItemCondition: z.nativeEnum(ItemCondition),
+});
+
+const displaySettingsSchema = z.object({
+  locale: z.enum(APP_LOCALES),
+  rtlPreference: rtlPreferenceSchema,
+});
+
+const businessRulesSchema = z.object({
+  agingThresholds: z
+    .tuple([
+      z.coerce.number().min(0),
+      z.coerce.number().min(0),
+      z.coerce.number().min(0),
+    ])
+    .transform((values) => values.map((value) => Math.round(value)) as [number, number, number]),
+  minimumMarginAlertPercent: z.coerce.number().min(0).max(100),
+  staleListingThresholds: z.object({
+    warning: z.coerce.number().min(0),
+    critical: z.coerce.number().min(0),
+  }),
+});
+
+export const appSettingsSchema = z.object({
+  general: generalSettingsSchema,
+  display: displaySettingsSchema,
+  businessRules: businessRulesSchema,
+});
+
+const appSettingsPartialSchema = appSettingsSchema.deepPartial();
+
+export type AppSettings = z.infer<typeof appSettingsSchema>;
+export type GeneralSettings = AppSettings['general'];
+export type DisplaySettings = AppSettings['display'];
+export type BusinessRulesSettings = AppSettings['businessRules'];
+
+export const DEFAULT_APP_SETTINGS: AppSettings = {
+  general: {
+    businessName: 'CoreX Inventory',
+    defaultChannel: Channel.DIRECT,
+    defaultItemCondition: ItemCondition.USED,
+  },
+  display: {
+    locale: 'fa',
+    rtlPreference: 'auto',
+  },
+  businessRules: {
+    agingThresholds: [30, 90, 180],
+    minimumMarginAlertPercent: 20,
+    staleListingThresholds: {
+      warning: 30,
+      critical: 60,
+    },
+  },
+};
+
+type FieldErrors<T> = Partial<Record<string, { message?: string }>> & {
+  _values?: T;
+  _all?: never;
+};
+
+function normalizeAgingThresholds(values: [number, number, number]): [number, number, number] {
+  const sorted = values
+    .map((value) => Math.max(0, Math.round(value)))
+    .sort((a, b) => a - b) as [number, number, number];
+
+  const normalized: [number, number, number] = [...sorted] as [number, number, number];
+  for (let index = 1; index < normalized.length; index += 1) {
+    if (normalized[index]! <= normalized[index - 1]!) {
+      normalized[index] = normalized[index - 1]! + 1;
+    }
+  }
+
+  return normalized;
+}
+
+function normalizeStaleThresholds(thresholds: BusinessRulesSettings['staleListingThresholds']): BusinessRulesSettings['staleListingThresholds'] {
+  const warning = Math.max(0, Math.round(thresholds.warning));
+  let critical = Math.max(0, Math.round(thresholds.critical));
+  if (critical <= warning) {
+    critical = warning + 1;
+  }
+
+  return { warning, critical };
+}
+
+function sanitizeBusinessRules(rules: BusinessRulesSettings): BusinessRulesSettings {
+  return {
+    agingThresholds: normalizeAgingThresholds(rules.agingThresholds),
+    minimumMarginAlertPercent: Math.min(100, Math.max(0, Math.round(rules.minimumMarginAlertPercent))),
+    staleListingThresholds: normalizeStaleThresholds(rules.staleListingThresholds),
+  };
+}
+
+function sanitizeDisplaySettings(settings: DisplaySettings): DisplaySettings {
+  const fallbackLocale = DEFAULT_APP_SETTINGS.display.locale;
+  const locale = APP_LOCALES.includes(settings.locale) ? settings.locale : fallbackLocale;
+  const rtlPreference = rtlPreferenceSchema.safeParse(settings.rtlPreference).success
+    ? settings.rtlPreference
+    : DEFAULT_APP_SETTINGS.display.rtlPreference;
+
+  return { locale, rtlPreference };
+}
+
+function sanitizeGeneralSettings(settings: GeneralSettings): GeneralSettings {
+  const trimmedName = settings.businessName.trim();
+  return {
+    businessName: trimmedName.length > 0 ? trimmedName : DEFAULT_APP_SETTINGS.general.businessName,
+    defaultChannel: settings.defaultChannel,
+    defaultItemCondition: settings.defaultItemCondition,
+  };
+}
+
+export function sanitizeAppSettings(settings: AppSettings): AppSettings {
+  return {
+    general: sanitizeGeneralSettings(settings.general),
+    display: sanitizeDisplaySettings(settings.display),
+    businessRules: sanitizeBusinessRules(settings.businessRules),
+  };
+}
+
+function mergeAppSettings(base: AppSettings, incoming: z.infer<typeof appSettingsPartialSchema>): AppSettings {
+  const general = incoming.general ? { ...base.general, ...incoming.general } : base.general;
+  const display = incoming.display ? { ...base.display, ...incoming.display } : base.display;
+
+  let businessRules = base.businessRules;
+  if (incoming.businessRules) {
+    const current = { ...businessRules };
+    if (incoming.businessRules.agingThresholds) {
+      const merged = [
+        incoming.businessRules.agingThresholds[0] ?? businessRules.agingThresholds[0],
+        incoming.businessRules.agingThresholds[1] ?? businessRules.agingThresholds[1],
+        incoming.businessRules.agingThresholds[2] ?? businessRules.agingThresholds[2],
+      ] as [number, number, number];
+      current.agingThresholds = normalizeAgingThresholds(merged);
+    }
+    if (incoming.businessRules.minimumMarginAlertPercent != null) {
+      current.minimumMarginAlertPercent = incoming.businessRules.minimumMarginAlertPercent;
+    }
+    if (incoming.businessRules.staleListingThresholds) {
+      current.staleListingThresholds = {
+        warning: incoming.businessRules.staleListingThresholds.warning ?? businessRules.staleListingThresholds.warning,
+        critical: incoming.businessRules.staleListingThresholds.critical ?? businessRules.staleListingThresholds.critical,
+      };
+    }
+    businessRules = sanitizeBusinessRules(current);
+  }
+
+  return sanitizeAppSettings({
+    general: sanitizeGeneralSettings(general),
+    display: sanitizeDisplaySettings(display),
+    businessRules,
+  });
+}
+
+export async function getSetting<T>(key: string, defaultValue: T): Promise<T> {
+  if (shouldUseMemoryStore) {
+    return (memoryStore.get(key) as T) ?? defaultValue;
+  }
+
+  try {
+    const record = await prisma.appSetting.findUnique({ where: { key } });
+    if (!record) {
+      return defaultValue;
+    }
+    return (record.value as T) ?? defaultValue;
+  } catch (error) {
+    console.warn('Failed to load setting', key, error);
+    return defaultValue;
+  }
+}
+
+export async function setSetting<T>(key: string, value: T): Promise<void> {
+  if (shouldUseMemoryStore) {
+    memoryStore.set(key, value as unknown as object);
+    return;
+  }
+
+  await prisma.appSetting.upsert({
+    where: { key },
+    update: { value: value as unknown as object },
+    create: { key, value: value as unknown as object },
+  });
+}
+
+export async function getAppSettings(): Promise<AppSettings> {
+  const stored = await getSetting<unknown>('app.settings', null);
+  if (!stored) {
+    return DEFAULT_APP_SETTINGS;
+  }
+
+  const parsed = appSettingsPartialSchema.safeParse(stored);
+  if (!parsed.success) {
+    return DEFAULT_APP_SETTINGS;
+  }
+
+  return mergeAppSettings(DEFAULT_APP_SETTINGS, parsed.data);
+}
+
+export async function setAppSettings(settings: AppSettings): Promise<AppSettings> {
+  const sanitized = sanitizeAppSettings(settings);
+  await setSetting('app.settings', sanitized);
+  return sanitized;
+}
+
+export async function getGeneralSettings(): Promise<GeneralSettings> {
+  const settings = await getAppSettings();
+  return settings.general;
+}
+
+export async function getDisplaySettings(): Promise<DisplaySettings> {
+  const settings = await getAppSettings();
+  return settings.display;
+}
+
+export async function getBusinessRulesSettings(): Promise<BusinessRulesSettings> {
+  const settings = await getAppSettings();
+  return settings.businessRules;
+}
+
+export type ResolverResult<T> = Promise<{ values: T; errors: FieldErrors<T> }>;
+
+export type FormResolver<T> = (values: T) => ResolverResult<T>;
+
+export function createZodResolver<T>(schema: z.ZodType<T>): FormResolver<T> {
+  return async (values: T) => {
+    const result = schema.safeParse(values);
+    if (result.success) {
+      return { values: result.data, errors: {} };
+    }
+
+    const errors: FieldErrors<T> = {};
+    for (const issue of result.error.issues) {
+      const path = issue.path.join('.');
+      if (!errors[path]) {
+        errors[path] = { message: issue.message };
+      }
+    }
+
+    return { values, errors };
+  };
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -9,6 +9,108 @@
     "settings": "Settings",
     "purchases": "Purchases"
   },
+  "settings": {
+    "title": "Workspace settings",
+    "subtitle": "Configure defaults, presentation, and operational rules.",
+    "tabs": {
+      "general": "General",
+      "display": "Display",
+      "rules": "Business rules",
+      "data": "Data"
+    },
+    "general": {
+      "businessName": {
+        "label": "Business name",
+        "placeholder": "CoreX",
+        "description": "Shown on exports and shared dashboards."
+      },
+      "defaultChannel": {
+        "label": "Default channel",
+        "placeholder": "Select channel",
+        "description": "Applied when logging purchases and sales."
+      },
+      "defaultCondition": {
+        "label": "Default item condition",
+        "placeholder": "Select condition",
+        "description": "Preselects the item condition for new entries."
+      }
+    },
+    "display": {
+      "locale": {
+        "label": "Default locale",
+        "placeholder": "Select locale",
+        "description": "Controls language, dates, and number formatting."
+      },
+      "rtl": {
+        "label": "Right-to-left layout",
+        "on": "Enabled",
+        "off": "Disabled",
+        "description": "Automatically enabled for Persian."
+      },
+      "currency": {
+        "label": "Currency",
+        "value": "Toman",
+        "description": "Values are stored as integers for accuracy."
+      },
+      "numberPreview": {
+        "label": "Number formatting preview"
+      }
+    },
+    "rules": {
+      "agingThresholds": {
+        "label": "Aging thresholds (days)",
+        "description": "Used for dashboard watchlists and report buckets.",
+        "labels": {
+          "0": "First threshold",
+          "1": "Second threshold",
+          "2": "Critical threshold"
+        }
+      },
+      "minimumMargin": {
+        "label": "Minimum margin alert (%)",
+        "description": "Flag sales that fall below the desired profit margin."
+      },
+      "staleThresholds": {
+        "label": "Stale listing thresholds (days)",
+        "description": "Controls when listed items appear in the stale queue.",
+        "warning": "Warning threshold",
+        "critical": "Critical threshold"
+      }
+    },
+    "data": {
+      "description": "Export or import operational data for external analysis.",
+      "helper": "Exports open in a new tab as JSON files.",
+      "exports": {
+        "reports": "Export reports",
+        "inventory": "Export inventory"
+      },
+      "import": {
+        "label": "Import products"
+      }
+    },
+    "actions": {
+      "reset": "Reset",
+      "save": "Save changes",
+      "saving": "Saving..."
+    },
+    "feedback": {
+      "saveSuccess": "Settings saved",
+      "saveError": "Unable to save settings",
+      "invalid": "Please fix the highlighted fields."
+    },
+    "options": {
+      "channels": {
+        "DIRECT": "Direct",
+        "ONLINE": "Online",
+        "WHOLESALE": "Wholesale",
+        "OTHER": "Other"
+      },
+      "locales": {
+        "fa": "Persian (fa)",
+        "en": "English (en)"
+      }
+    }
+  },
   "dashboard": {
     "title": "Operations dashboard",
     "subtitle": "Track revenue, inventory health, and next actions.",
@@ -42,14 +144,14 @@
       "ageLabel": "{count} days",
       "aging": {
         "title": "Aging watchlist",
-        "description": "{over90} items older than 90 days · {over180} beyond 180",
-        "badge180": "180+ days",
+        "description": "{warningCount} items older than {warningDays} days · {criticalCount} beyond {criticalDays}",
+        "badgeCritical": "{days}+ days",
         "empty": "No aging risk items."
       },
       "stale": {
         "title": "Listed but stale",
-        "description": "{over30} listings older than 30 days · {over60} past 60",
-        "badge60": "60+ days",
+        "description": "{warningCount} listings older than {warningDays} days · {criticalCount} past {criticalDays}",
+        "badgeCritical": "{days}+ days",
         "empty": "No stale listings."
       }
     }

--- a/messages/fa.json
+++ b/messages/fa.json
@@ -9,6 +9,108 @@
     "settings": "تنظیمات",
     "purchases": "خریدها"
   },
+  "settings": {
+    "title": "تنظیمات سیستم",
+    "subtitle": "پیش‌فرض‌ها، نحوه نمایش و قوانین کاری را مدیریت کنید.",
+    "tabs": {
+      "general": "عمومی",
+      "display": "نمایش",
+      "rules": "قوانین کسب‌وکار",
+      "data": "داده"
+    },
+    "general": {
+      "businessName": {
+        "label": "نام کسب‌وکار",
+        "placeholder": "CoreX",
+        "description": "در خروجی‌ها و داشبوردهای اشتراکی نمایش داده می‌شود."
+      },
+      "defaultChannel": {
+        "label": "کانال پیش‌فرض",
+        "placeholder": "انتخاب کانال",
+        "description": "هنگام ثبت خرید و فروش به صورت خودکار استفاده می‌شود."
+      },
+      "defaultCondition": {
+        "label": "وضعیت پیش‌فرض کالا",
+        "placeholder": "انتخاب وضعیت",
+        "description": "برای ثبت آیتم‌های جدید به صورت پیش‌فرض انتخاب می‌شود."
+      }
+    },
+    "display": {
+      "locale": {
+        "label": "زبان پیش‌فرض",
+        "placeholder": "انتخاب زبان",
+        "description": "بر نمایش زبان، تاریخ و اعداد اثر می‌گذارد."
+      },
+      "rtl": {
+        "label": "چیدمان راست‌به‌چپ",
+        "on": "فعال",
+        "off": "غیرفعال",
+        "description": "برای فارسی به صورت خودکار فعال است."
+      },
+      "currency": {
+        "label": "واحد پول",
+        "value": "تومان",
+        "description": "ارقام برای دقت بیشتر به‌صورت عدد صحیح ذخیره می‌شوند."
+      },
+      "numberPreview": {
+        "label": "نمونه قالب‌بندی عدد"
+      }
+    },
+    "rules": {
+      "agingThresholds": {
+        "label": "آستانه‌های فرسودگی (روز)",
+        "description": "در داشبورد و گزارش‌ها برای دسته‌بندی استفاده می‌شود.",
+        "labels": {
+          "0": "آستانه اول",
+          "1": "آستانه دوم",
+          "2": "آستانه بحرانی"
+        }
+      },
+      "minimumMargin": {
+        "label": "هشدار حداقل حاشیه سود (%)",
+        "description": "فروش‌هایی که زیر این حاشیه باشند هشدار می‌گیرند."
+      },
+      "staleThresholds": {
+        "label": "آستانه‌های آگهی راکد (روز)",
+        "description": "زمان نمایش آگهی‌های راکد را تعیین می‌کند.",
+        "warning": "آستانه هشدار",
+        "critical": "آستانه بحرانی"
+      }
+    },
+    "data": {
+      "description": "داده‌های عملیاتی را برای تحلیل خارجی خروجی یا وارد کنید.",
+      "helper": "خروجی‌ها در تب جدید به صورت JSON باز می‌شوند.",
+      "exports": {
+        "reports": "خروجی گزارش‌ها",
+        "inventory": "خروجی موجودی"
+      },
+      "import": {
+        "label": "ورود محصولات"
+      }
+    },
+    "actions": {
+      "reset": "بازنشانی",
+      "save": "ذخیره تغییرات",
+      "saving": "در حال ذخیره..."
+    },
+    "feedback": {
+      "saveSuccess": "تنظیمات ذخیره شد",
+      "saveError": "ذخیره تنظیمات ممکن نشد",
+      "invalid": "خطاهای مشخص‌شده را برطرف کنید."
+    },
+    "options": {
+      "channels": {
+        "DIRECT": "مستقیم",
+        "ONLINE": "آنلاین",
+        "WHOLESALE": "عمده‌فروشی",
+        "OTHER": "سایر"
+      },
+      "locales": {
+        "fa": "فارسی (fa)",
+        "en": "انگلیسی (en)"
+      }
+    }
+  },
   "dashboard": {
     "title": "داشبورد عملیات",
     "subtitle": "عملکرد مالی و سلامت موجودی را پایش کنید.",
@@ -42,14 +144,14 @@
       "ageLabel": "{count} روز",
       "aging": {
         "title": "هشدار فرسودگی",
-        "description": "{over90} آیتم بالای ۹۰ روز · {over180} بالای ۱۸۰",
-        "badge180": "۱۸۰+ روز",
+        "description": "{warningCount} آیتم بالای {warningDays} روز · {criticalCount} بیش از {criticalDays} روز",
+        "badgeCritical": "{days}+ روز",
         "empty": "آیتم قدیمی وجود ندارد."
       },
       "stale": {
         "title": "لیست‌شده اما راکد",
-        "description": "{over30} لیست بالای ۳۰ روز · {over60} بالای ۶۰",
-        "badge60": "۶۰+ روز",
+        "description": "{warningCount} لیست بالای {warningDays} روز · {criticalCount} بیش از {criticalDays} روز",
+        "badgeCritical": "{days}+ روز",
         "empty": "لیست راکدی وجود ندارد."
       }
     }

--- a/prisma/migrations/20251015120000_add_app_setting_table/migration.sql
+++ b/prisma/migrations/20251015120000_add_app_setting_table/migration.sql
@@ -1,0 +1,5 @@
+CREATE TABLE "AppSetting" (
+    "key" TEXT NOT NULL,
+    "value" JSONB NOT NULL,
+    CONSTRAINT "AppSetting_pkey" PRIMARY KEY ("key")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -160,3 +160,8 @@ model InventoryMovement {
   notes     String?
   createdAt DateTime     @default(now())
 }
+
+model AppSetting {
+  key   String @id
+  value Json
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -27,6 +27,7 @@ async function main() {
   await safeDelete('item');
   await safeDelete('product');
   await safeDelete('category');
+  await safeDelete('appSetting');
 
   // --- Categories (with simple tree) ---
   const categoriesData = [
@@ -325,7 +326,35 @@ async function main() {
     }
   } catch {/* ignore */}
 
-  console.log('✅ Seed completed with categories, products, items (>50), inventory movements, and sample sales/purchases (if supported).');
+  const defaultSettings = {
+    general: {
+      businessName: 'CoreX Inventory',
+      defaultChannel: Channel.DIRECT,
+      defaultItemCondition: ItemCondition.USED,
+    },
+    display: {
+      locale: 'fa',
+      rtlPreference: 'auto',
+    },
+    businessRules: {
+      agingThresholds: [30, 90, 180],
+      minimumMarginAlertPercent: 20,
+      staleListingThresholds: {
+        warning: 30,
+        critical: 60,
+      },
+    },
+  } as const;
+
+  try {
+    await anyPrisma.appSetting.upsert({
+      where: { key: 'app.settings' },
+      update: { value: defaultSettings },
+      create: { key: 'app.settings', value: defaultSettings },
+    });
+  } catch {/* ignore */}
+
+  console.log('✅ Seed completed with categories, products, items (>50), inventory movements, sample sales/purchases, and default settings (if supported).');
 }
 
 main()

--- a/src/app/[locale]/dashboard/_components/KpiSection.tsx
+++ b/src/app/[locale]/dashboard/_components/KpiSection.tsx
@@ -34,11 +34,7 @@ export default async function KpiSection({ locale }: KpiSectionProps) {
   const currencyFormatter = getCurrencyFormatter(locale);
   const monthToDateLabel = getMonthToDateLabel(locale);
 
-  const activeCount =
-    agingBuckets['0-30'].count +
-    agingBuckets['31-90'].count +
-    agingBuckets['91-180'].count +
-    agingBuckets['181+'].count;
+  const activeCount = agingBuckets.reduce((sum, bucket) => sum + bucket.count, 0);
 
   return (
     <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">

--- a/src/app/[locale]/reports/page.tsx
+++ b/src/app/[locale]/reports/page.tsx
@@ -12,6 +12,7 @@ import {
   getReportsAggregates,
   serializeFilters,
 } from '../../../../lib/reporting-data';
+import { getBusinessRulesSettings } from '../../../../lib/settings';
 
 export const dynamic = 'force-dynamic';
 
@@ -78,7 +79,8 @@ export default async function ReportsPage({ searchParams }: ReportsPageProps) {
   const defaults = defaultFilters();
   const { channels, categories } = getAvailableFilters();
   const filters = buildFilters(resolvedParams, defaults, channels, categories);
-  const aggregates = getReportsAggregates(filters);
+  const businessRules = await getBusinessRulesSettings();
+  const aggregates = getReportsAggregates(filters, businessRules);
   const serialized: SerializedFilters = serializeFilters(filters);
 
   return (

--- a/src/app/[locale]/settings/_components/SettingsTabs.tsx
+++ b/src/app/[locale]/settings/_components/SettingsTabs.tsx
@@ -1,0 +1,364 @@
+'use client';
+
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+import { useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { useForm } from 'react-hook-form';
+
+import type { AppLocale } from '../../../../../i18n/routing';
+import { formatToman } from '../../../../../lib/money';
+import {
+  type AppSettings,
+  appSettingsSchema,
+  createZodResolver,
+  sanitizeAppSettings,
+} from '../../../../../lib/settings';
+
+const CHANNEL_OPTIONS = ['DIRECT', 'ONLINE', 'WHOLESALE', 'OTHER'] as const;
+const CONDITION_OPTIONS = ['NEW', 'USED', 'FOR_PARTS'] as const;
+const LOCALE_OPTIONS: AppLocale[] = ['fa', 'en'];
+
+interface SettingsTabsProps {
+  locale: AppLocale;
+  initialSettings: AppSettings;
+}
+
+type TabsValue = 'general' | 'display' | 'rules' | 'data';
+
+type SettingsFormValues = AppSettings;
+
+async function saveSettings(values: SettingsFormValues) {
+  const response = await fetch('/api/settings', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(values),
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || 'Request failed');
+  }
+
+  return (await response.json()) as AppSettings;
+}
+
+export default function SettingsTabs({ locale, initialSettings }: SettingsTabsProps) {
+  const t = useTranslations('settings');
+  const tConditions = useTranslations('conditions');
+  const [activeTab, setActiveTab] = useState<TabsValue>('general');
+
+  const form = useForm<SettingsFormValues>({
+    defaultValues: initialSettings,
+    resolver: createZodResolver(appSettingsSchema),
+  });
+
+  const localeValue = (form.watch('display.locale') as AppLocale) ?? locale;
+  const rtlPreference = form.watch('display.rtlPreference');
+  const intlLocale = localeValue === 'fa' ? 'fa-IR' : 'en-US';
+  const isRtl = rtlPreference === 'rtl' || (rtlPreference === 'auto' && localeValue === 'fa');
+
+  useEffect(() => {
+    if (localeValue === 'fa') {
+      form.setValue('display.rtlPreference', 'auto');
+    }
+  }, [form, localeValue]);
+
+  const numberPreview = useMemo(() => {
+    const numberFormatter = new Intl.NumberFormat(intlLocale, { maximumFractionDigits: 2 });
+    const sampleNumber = 1234567.89;
+    return {
+      decimal: numberFormatter.format(sampleNumber),
+      currency: formatToman(9876543, intlLocale),
+    };
+  }, [intlLocale]);
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    try {
+      const saved = await saveSettings(values);
+      form.reset(sanitizeAppSettings(saved));
+      toast.success(t('feedback.saveSuccess'));
+    } catch (error) {
+      console.error(error);
+      toast.error(t('feedback.saveError'));
+    }
+  }, () => {
+    toast.error(t('feedback.invalid'));
+  });
+
+  const handleReset = () => {
+    form.reset(initialSettings);
+  };
+
+  const handleRtlToggle = (checked: boolean) => {
+    if (localeValue === 'fa') {
+      form.setValue('display.rtlPreference', 'auto');
+      return;
+    }
+    form.setValue('display.rtlPreference', checked ? 'rtl' : 'ltr');
+  };
+
+  return (
+    <Form form={form}>
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as TabsValue)}>
+          <TabsList className="mb-4">
+            <TabsTrigger value="general">{t('tabs.general')}</TabsTrigger>
+            <TabsTrigger value="display">{t('tabs.display')}</TabsTrigger>
+            <TabsTrigger value="rules">{t('tabs.rules')}</TabsTrigger>
+            <TabsTrigger value="data">{t('tabs.data')}</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="general" className="space-y-6">
+            <div className="grid gap-6 md:grid-cols-2">
+              <FormField
+                name="general.businessName"
+                render={({ field }) => (
+                  <FormItem className="space-y-2">
+                    <FormLabel>{t('general.businessName.label')}</FormLabel>
+                    <FormControl>
+                      <Input {...field} placeholder={t('general.businessName.placeholder')} />
+                    </FormControl>
+                    <FormDescription>{t('general.businessName.description')}</FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                name="general.defaultChannel"
+                render={({ field }) => (
+                  <FormItem className="space-y-2">
+                    <FormLabel>{t('general.defaultChannel.label')}</FormLabel>
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder={t('general.defaultChannel.placeholder')} />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {CHANNEL_OPTIONS.map((option) => (
+                          <SelectItem key={option} value={option}>
+                            {t(`options.channels.${option}` as const)}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormDescription>{t('general.defaultChannel.description')}</FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <FormField
+              name="general.defaultItemCondition"
+              render={({ field }) => (
+                <FormItem className="space-y-2">
+                  <FormLabel>{t('general.defaultCondition.label')}</FormLabel>
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder={t('general.defaultCondition.placeholder')} />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {CONDITION_OPTIONS.map((option) => (
+                        <SelectItem key={option} value={option}>
+                          {tConditions(option)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormDescription>{t('general.defaultCondition.description')}</FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </TabsContent>
+
+          <TabsContent value="display" className="space-y-6">
+            <div className="grid gap-6 md:grid-cols-2">
+              <FormField
+                name="display.locale"
+                render={({ field }) => (
+                  <FormItem className="space-y-2">
+                    <FormLabel>{t('display.locale.label')}</FormLabel>
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder={t('display.locale.placeholder')} />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {LOCALE_OPTIONS.map((option) => (
+                          <SelectItem key={option} value={option}>
+                            {t(`options.locales.${option}` as const)}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormDescription>{t('display.locale.description')}</FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                name="display.rtlPreference"
+                render={() => (
+                  <FormItem className="space-y-2">
+                    <FormLabel>{t('display.rtl.label')}</FormLabel>
+                    <div className="flex items-center gap-3">
+                      <Switch
+                        checked={isRtl}
+                        onCheckedChange={handleRtlToggle}
+                        disabled={localeValue === 'fa'}
+                        aria-label={t('display.rtl.label')}
+                      />
+                      <span className="text-sm text-[var(--muted-strong)]">
+                        {isRtl ? t('display.rtl.on') : t('display.rtl.off')}
+                      </span>
+                    </div>
+                    <FormDescription>{t('display.rtl.description')}</FormDescription>
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <div className="grid gap-6 md:grid-cols-2">
+              <div className="space-y-2">
+                <FormLabel>{t('display.currency.label')}</FormLabel>
+                <div className="rounded-lg border border-dashed border-[var(--border)] bg-[var(--surface-muted)] p-4 text-sm text-[var(--muted-strong)]">
+                  <div className="font-semibold">{t('display.currency.value')}</div>
+                  <div className="text-xs text-[var(--muted)]">{t('display.currency.description')}</div>
+                </div>
+              </div>
+              <div className="space-y-2">
+                <FormLabel>{t('display.numberPreview.label')}</FormLabel>
+                <div
+                  className="rounded-lg border border-[var(--border)] bg-[var(--surface)] p-4 text-sm text-[var(--muted-strong)]"
+                  dir={isRtl ? 'rtl' : 'ltr'}
+                >
+                  <div>{numberPreview.decimal}</div>
+                  <div className="text-xs text-[var(--muted)]">{numberPreview.currency}</div>
+                </div>
+              </div>
+            </div>
+          </TabsContent>
+
+          <TabsContent value="rules" className="space-y-6">
+            <div className="space-y-4">
+              <FormLabel>{t('rules.agingThresholds.label')}</FormLabel>
+              <FormDescription>{t('rules.agingThresholds.description')}</FormDescription>
+              <div className="grid gap-4 md:grid-cols-3">
+                {[0, 1, 2].map((index) => (
+                  <FormField
+                    key={index}
+                    name={`businessRules.agingThresholds.${index}`}
+                    render={({ field }) => (
+                      <FormItem className="space-y-2">
+                        <FormLabel>{t(`rules.agingThresholds.labels.${index}` as const)}</FormLabel>
+                        <FormControl>
+                          <Input type="number" min={0} {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                ))}
+              </div>
+            </div>
+
+            <FormField
+              name="businessRules.minimumMarginAlertPercent"
+              render={({ field }) => (
+                <FormItem className="space-y-2">
+                  <FormLabel>{t('rules.minimumMargin.label')}</FormLabel>
+                  <FormControl>
+                    <Input type="number" min={0} max={100} {...field} />
+                  </FormControl>
+                  <FormDescription>{t('rules.minimumMargin.description')}</FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div className="space-y-4">
+              <FormLabel>{t('rules.staleThresholds.label')}</FormLabel>
+              <FormDescription>{t('rules.staleThresholds.description')}</FormDescription>
+              <div className="grid gap-4 md:grid-cols-2">
+                <FormField
+                  name="businessRules.staleListingThresholds.warning"
+                  render={({ field }) => (
+                    <FormItem className="space-y-2">
+                      <FormLabel>{t('rules.staleThresholds.warning')}</FormLabel>
+                      <FormControl>
+                        <Input type="number" min={0} {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  name="businessRules.staleListingThresholds.critical"
+                  render={({ field }) => (
+                    <FormItem className="space-y-2">
+                      <FormLabel>{t('rules.staleThresholds.critical')}</FormLabel>
+                      <FormControl>
+                        <Input type="number" min={0} {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            </div>
+          </TabsContent>
+
+          <TabsContent value="data" className="space-y-4">
+            <div className="space-y-2">
+              <p className="text-sm text-[var(--muted-strong)]">{t('data.description')}</p>
+              <p className="text-xs text-[var(--muted)]">{t('data.helper')}</p>
+            </div>
+            <div className="flex flex-wrap gap-3">
+              <Link href="/api/reports/export" target="_blank" rel="noreferrer">
+                <Button type="button" variant="outline">
+                  {t('data.exports.reports')}
+                </Button>
+              </Link>
+              <Link href="/api/reports/export?scope=inventory" target="_blank" rel="noreferrer">
+                <Button type="button" variant="outline">
+                  {t('data.exports.inventory')}
+                </Button>
+              </Link>
+              <Link href="/products/import">
+                <Button type="button" variant="ghost">
+                  {t('data.import.label')}
+                </Button>
+              </Link>
+            </div>
+          </TabsContent>
+        </Tabs>
+
+        <div className="flex flex-wrap items-center justify-end gap-3 border-t border-[var(--border)] pt-4">
+          <Button type="button" variant="ghost" onClick={handleReset}>
+            {t('actions.reset')}
+          </Button>
+          <Button type="submit" disabled={form.formState.isSubmitting}>
+            {form.formState.isSubmitting ? t('actions.saving') : t('actions.save')}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/src/app/[locale]/settings/page.tsx
+++ b/src/app/[locale]/settings/page.tsx
@@ -1,0 +1,28 @@
+import { getLocale, getTranslations } from 'next-intl/server';
+
+import PageHeader from '@/components/PageHeader';
+
+import type { AppLocale } from '../../../../i18n/routing';
+import { getAppSettings } from '../../../../lib/settings';
+
+import SettingsTabs from './_components/SettingsTabs';
+
+export const dynamic = 'force-dynamic';
+
+type SettingsPageProps = {
+  params: Promise<{ locale: string }>;
+};
+
+export default async function SettingsPage({ params }: SettingsPageProps) {
+  const locale = (await getLocale()) as AppLocale;
+  const resolvedParams = await params;
+  const t = await getTranslations({ locale, namespace: 'settings' });
+  const settings = await getAppSettings();
+
+  return (
+    <section className="space-y-6">
+      <PageHeader title={t('title')} description={t('subtitle')} />
+      <SettingsTabs locale={(resolvedParams.locale as AppLocale) ?? locale} initialSettings={settings} />
+    </section>
+  );
+}

--- a/src/app/api/reports/export/route.ts
+++ b/src/app/api/reports/export/route.ts
@@ -7,6 +7,7 @@ import {
   getReportsAggregates,
   serializeFilters,
 } from '../../../../../lib/reporting-data';
+import { getBusinessRulesSettings } from '../../../../../lib/settings';
 
 function parseChannels(params: URLSearchParams, available: ReportChannel[]): ReportChannel[] {
   const allowed = new Set<ReportChannel>(available);
@@ -36,7 +37,8 @@ export async function GET(request: Request) {
     category: categoryParam?.trim() ? categoryParam : null,
   } as const;
 
-  const aggregates = getReportsAggregates(filters);
+  const businessRules = await getBusinessRulesSettings();
+  const aggregates = getReportsAggregates(filters, businessRules);
 
   return NextResponse.json({ filters: serializeFilters(filters), aggregates });
 }

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+
+import {
+  appSettingsSchema,
+  getAppSettings,
+  sanitizeAppSettings,
+  setAppSettings,
+} from '../../../../lib/settings';
+
+export async function GET() {
+  const settings = await getAppSettings();
+  return NextResponse.json(settings);
+}
+
+export async function POST(request: Request) {
+  try {
+    const payload = await request.json();
+    const parsed = appSettingsSchema.safeParse(payload);
+    if (!parsed.success) {
+      return NextResponse.json({ message: 'Invalid settings payload', issues: parsed.error.format() }, { status: 400 });
+    }
+
+    const saved = await setAppSettings(parsed.data);
+    return NextResponse.json(sanitizeAppSettings(saved));
+  } catch (error) {
+    console.error('Failed to save settings', error);
+    return NextResponse.json({ message: 'Unable to save settings' }, { status: 500 });
+  }
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { forwardRef } from 'react';
+
+function cx(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(' ');
+}
+
+const VARIANTS: Record<string, string> = {
+  default:
+    'bg-[var(--accent)] text-white hover:bg-[var(--accent-hover)] focus-visible:ring-[var(--accent)] disabled:bg-[var(--surface-muted)] disabled:text-[var(--muted)]',
+  secondary:
+    'bg-[var(--surface-muted)] text-[var(--muted-strong)] hover:bg-[var(--surface-hover)] focus-visible:ring-[var(--border-strong)] disabled:bg-[var(--surface-muted)] disabled:text-[var(--muted)]',
+  outline:
+    'border border-[var(--border)] bg-[var(--surface)] text-[var(--muted-strong)] hover:border-[var(--accent)] focus-visible:ring-[var(--accent)] disabled:text-[var(--muted)]',
+  ghost:
+    'text-[var(--muted-strong)] hover:bg-[var(--surface-muted)] focus-visible:ring-[var(--border-strong)] disabled:text-[var(--muted)]',
+};
+
+const SIZES: Record<string, string> = {
+  md: 'px-4 py-2 text-sm',
+  sm: 'px-3 py-1.5 text-xs',
+};
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: keyof typeof VARIANTS;
+  size?: keyof typeof SIZES;
+}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  { className, variant = 'default', size = 'md', type = 'button', ...props },
+  ref,
+) {
+  return (
+    <button
+      ref={ref}
+      type={type}
+      className={cx(
+        'inline-flex items-center justify-center gap-2 rounded-lg font-medium transition focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface)] disabled:cursor-not-allowed',
+        VARIANTS[variant] ?? VARIANTS.default,
+        SIZES[size] ?? SIZES.md,
+        className,
+      )}
+      {...props}
+    />
+  );
+});

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import type { ChangeEvent } from 'react';
+import { cloneElement, createContext, useContext, useId } from 'react';
+
+import type { FormState, UseFormReturn } from '../../lib/react-hook-form';
+
+interface FormContextValue<T> {
+  form: UseFormReturn<T>;
+}
+
+const FormContext = createContext<FormContextValue<any> | null>(null);
+
+export function Form<T>({ form, children }: { form: UseFormReturn<T>; children: React.ReactNode }) {
+  return <FormContext.Provider value={{ form }}>{children}</FormContext.Provider>;
+}
+
+function useFormContext<T>() {
+  const context = useContext(FormContext);
+  if (!context) {
+    throw new Error('Form components must be used within <Form>');
+  }
+  return context.form as UseFormReturn<T>;
+}
+
+interface FormFieldContextValue {
+  name: string;
+  id: string;
+  error?: { message?: string };
+}
+
+const FormFieldContext = createContext<FormFieldContextValue | null>(null);
+
+export interface FormFieldRenderProps<T> {
+  field: {
+    name: string;
+    value: unknown;
+    onChange: (event: unknown) => void;
+    onBlur: () => void;
+  };
+  fieldState: {
+    error?: { message?: string };
+  };
+  formState: FormState<T>;
+}
+
+export interface FormFieldProps<T> {
+  name: string;
+  render: (props: FormFieldRenderProps<T>) => React.ReactNode;
+}
+
+export function FormField<T>({ name, render }: FormFieldProps<T>) {
+  const form = useFormContext<T>();
+  const id = useId();
+  const value = form.watch(name) as unknown;
+  const error = form.formState.errors[name] as { message?: string } | undefined;
+
+  const handleChange = (next: unknown) => {
+    if (next && typeof (next as { target?: unknown }) === 'object' && (next as any)?.target) {
+      const event = next as ChangeEvent<HTMLInputElement | HTMLTextAreaElement>;
+      const target = event.target as HTMLInputElement | HTMLTextAreaElement;
+      form.setValue(name, target.type === 'number' ? target.valueAsNumber : target.value);
+      return;
+    }
+    form.setValue(name, next);
+  };
+
+  return (
+    <FormFieldContext.Provider value={{ name, id, error }}>
+      {render({
+        field: {
+          name,
+          value,
+          onChange: handleChange,
+          onBlur: () => undefined,
+        },
+        fieldState: { error },
+        formState: form.formState,
+      })}
+    </FormFieldContext.Provider>
+  );
+}
+
+function useFormFieldContext() {
+  const context = useContext(FormFieldContext);
+  if (!context) {
+    throw new Error('Form components must be used within FormField');
+  }
+  return context;
+}
+
+export function FormItem({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <div className={className}>{children}</div>;
+}
+
+export function FormLabel({ children, className }: { children: React.ReactNode; className?: string }) {
+  const { id } = useFormFieldContext();
+  return (
+    <label htmlFor={id} className={['text-sm font-medium text-[var(--muted-strong)]', className].filter(Boolean).join(' ')}>
+      {children}
+    </label>
+  );
+}
+
+export function FormControl({ children }: { children: React.ReactElement }) {
+  const { id, error } = useFormFieldContext();
+  return cloneElement(children, {
+    id,
+    'aria-invalid': error ? 'true' : undefined,
+    'aria-describedby': error ? `${id}-message` : undefined,
+  });
+}
+
+export function FormDescription({ children, className }: { children: React.ReactNode; className?: string }) {
+  const { id } = useFormFieldContext();
+  return (
+    <p id={`${id}-description`} className={['text-xs text-[var(--muted)]', className].filter(Boolean).join(' ')}>
+      {children}
+    </p>
+  );
+}
+
+export function FormMessage({ className }: { className?: string }) {
+  const { error, id } = useFormFieldContext();
+  if (!error?.message) {
+    return null;
+  }
+  return (
+    <p id={`${id}-message`} className={['text-xs text-[var(--warning)]', className].filter(Boolean).join(' ')}>
+      {error.message}
+    </p>
+  );
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { forwardRef } from 'react';
+
+function cx(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(' ');
+}
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(function Input({ className, type = 'text', ...props }, ref) {
+  return (
+    <input
+      ref={ref}
+      type={type}
+      className={cx(
+        'block w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-sm text-[var(--foreground)] shadow-sm transition focus:border-[var(--accent)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)] focus:ring-offset-2 focus:ring-offset-[var(--surface)] disabled:cursor-not-allowed disabled:bg-[var(--surface-muted)] disabled:text-[var(--muted)]',
+        className,
+      )}
+      {...props}
+    />
+  );
+});

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { forwardRef } from 'react';
+
+function cx(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(' ');
+}
+
+export type LabelProps = React.LabelHTMLAttributes<HTMLLabelElement>;
+
+export const Label = forwardRef<HTMLLabelElement, LabelProps>(function Label({ className, ...props }, ref) {
+  return (
+    <label
+      ref={ref}
+      className={cx('text-sm font-medium text-[var(--muted-strong)]', className)}
+      {...props}
+    />
+  );
+});

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { forwardRef } from 'react';
+
+function cx(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(' ');
+}
+
+export interface SwitchProps extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'onChange'> {
+  checked?: boolean;
+  onCheckedChange?: (checked: boolean) => void;
+}
+
+export const Switch = forwardRef<HTMLButtonElement, SwitchProps>(function Switch(
+  { checked = false, onCheckedChange, className, disabled, ...props },
+  ref,
+) {
+  return (
+    <button
+      ref={ref}
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      disabled={disabled}
+      onClick={() => {
+        if (disabled) return;
+        onCheckedChange?.(!checked);
+      }}
+      className={cx(
+        'relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface)]',
+        checked ? 'bg-[var(--accent)]' : 'bg-[var(--surface-muted)]',
+        disabled && 'cursor-not-allowed opacity-60',
+        className,
+      )}
+      {...props}
+    >
+      <span
+        aria-hidden="true"
+        className={cx(
+          'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow transition',
+          checked ? 'translate-x-5' : 'translate-x-1',
+        )}
+      />
+    </button>
+  );
+});

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { createContext, useCallback, useContext, useEffect, useId, useMemo, useState } from 'react';
+
+function cx(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(' ');
+}
+
+type TabsContextValue = {
+  value: string;
+  setValue: (value: string) => void;
+  id: string;
+};
+
+const TabsContext = createContext<TabsContextValue | null>(null);
+
+export interface TabsProps {
+  value?: string;
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function Tabs({ value, defaultValue, onValueChange, children, className }: TabsProps) {
+  const generatedId = useId();
+  const [internalValue, setInternalValue] = useState(defaultValue ?? value ?? '');
+
+  useEffect(() => {
+    if (typeof value === 'string') {
+      setInternalValue(value);
+    }
+  }, [value]);
+
+  const handleChange = useCallback(
+    (next: string) => {
+      if (value == null) {
+        setInternalValue(next);
+      }
+      onValueChange?.(next);
+    },
+    [onValueChange, value],
+  );
+
+  const context = useMemo<TabsContextValue>(
+    () => ({
+      value: value ?? internalValue,
+      setValue: handleChange,
+      id: generatedId,
+    }),
+    [generatedId, handleChange, internalValue, value],
+  );
+
+  return (
+    <TabsContext.Provider value={context}>
+      <div className={className}>{children}</div>
+    </TabsContext.Provider>
+  );
+}
+
+export interface TabsListProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function TabsList({ children, className }: TabsListProps) {
+  return (
+    <div
+      role="tablist"
+      className={cx('flex gap-2 rounded-xl bg-[var(--surface-muted)] p-1 text-sm font-medium', className)}
+    >
+      {children}
+    </div>
+  );
+}
+
+export interface TabsTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  value: string;
+}
+
+export function TabsTrigger({ value, className, children, ...props }: TabsTriggerProps) {
+  const context = useContext(TabsContext);
+  if (!context) {
+    throw new Error('TabsTrigger must be used within Tabs');
+  }
+  const isActive = context.value === value;
+  const triggerId = `${context.id}-trigger-${value}`;
+  const contentId = `${context.id}-content-${value}`;
+
+  return (
+    <button
+      type="button"
+      role="tab"
+      id={triggerId}
+      aria-controls={contentId}
+      aria-selected={isActive}
+      onClick={() => context.setValue(value)}
+      className={cx(
+        'flex-1 rounded-lg px-4 py-2 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-muted)]',
+        isActive
+          ? 'bg-[var(--surface)] text-[var(--foreground)] shadow-sm'
+          : 'text-[var(--muted)] hover:text-[var(--muted-strong)]',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+export interface TabsContentProps {
+  value: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function TabsContent({ value, className, children }: TabsContentProps) {
+  const context = useContext(TabsContext);
+  if (!context) {
+    throw new Error('TabsContent must be used within Tabs');
+  }
+
+  const isActive = context.value === value;
+  const contentId = `${context.id}-content-${value}`;
+  const triggerId = `${context.id}-trigger-${value}`;
+
+  return (
+    <div
+      id={contentId}
+      role="tabpanel"
+      aria-labelledby={triggerId}
+      hidden={!isActive}
+      className={cx(isActive ? 'mt-4' : 'hidden', className)}
+    >
+      {isActive ? children : null}
+    </div>
+  );
+}

--- a/src/lib/react-hook-form.ts
+++ b/src/lib/react-hook-form.ts
@@ -1,0 +1,198 @@
+'use client';
+
+import type { ChangeEvent, FormEvent } from 'react';
+import { useCallback, useMemo, useState } from 'react';
+
+import type { FormResolver } from '../../lib/settings';
+
+type FieldError = { message?: string };
+export type FieldErrors<T> = Record<string, FieldError> & { _values?: T };
+
+function splitPath(name: string): string[] {
+  return name.split('.').filter(Boolean);
+}
+
+function isNumericKey(key: string): boolean {
+  return /^\d+$/.test(key);
+}
+
+function getNestedValue<T>(object: T, path: string[]): unknown {
+  return path.reduce<unknown>((accumulator, key) => {
+    if (accumulator == null) {
+      return undefined;
+    }
+    const actualKey = isNumericKey(key) ? Number.parseInt(key, 10) : key;
+    // @ts-expect-error -- dynamic access
+    return accumulator[actualKey];
+  }, object as unknown);
+}
+
+function cloneArray(source: unknown): unknown[] {
+  return Array.isArray(source) ? [...source] : [];
+}
+
+function setNestedValue<T>(object: T, path: string[], value: unknown): T {
+  if (path.length === 0) {
+    return value as T;
+  }
+
+  const [head, ...rest] = path;
+  if (isNumericKey(head)) {
+    const index = Number.parseInt(head, 10);
+    const array = cloneArray(object);
+    array[index] = rest.length === 0 ? value : setNestedValue(array[index], rest, value);
+    return array as T;
+  }
+
+  const current = (object && typeof object === 'object' && !Array.isArray(object)) ? { ...(object as object) } : {};
+  // @ts-expect-error -- dynamic write
+  current[head] = rest.length === 0 ? value : setNestedValue(current[head], rest, value);
+  return current as T;
+}
+
+export type UseFormOptions<T> = {
+  defaultValues: T;
+  resolver?: FormResolver<T>;
+};
+
+export type UseFormHandleSubmit<T> = (
+  onValid: (values: T) => void | Promise<void>,
+  onInvalid?: (errors: FieldErrors<T>) => void,
+) => (event?: FormEvent<HTMLFormElement>) => void;
+
+export type RegisteredField = {
+  name: string;
+  value: unknown;
+  onChange: (event: ChangeEvent<HTMLInputElement> | unknown) => void;
+  onBlur: () => void;
+};
+
+export type FormState<T> = {
+  isSubmitting: boolean;
+  isDirty: boolean;
+  errors: FieldErrors<T>;
+};
+
+export type UseFormReturn<T> = {
+  register: (name: string) => RegisteredField;
+  handleSubmit: UseFormHandleSubmit<T>;
+  setValue: (name: string, value: unknown) => void;
+  watch: (name?: string) => unknown;
+  reset: (values?: T) => void;
+  formState: FormState<T>;
+  values: T;
+};
+
+export function useForm<T>({ defaultValues, resolver }: UseFormOptions<T>): UseFormReturn<T> {
+  const [values, setValues] = useState<T>(defaultValues);
+  const [errors, setErrors] = useState<FieldErrors<T>>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isDirty, setIsDirty] = useState(false);
+
+  const updateValue = useCallback((name: string, nextValue: unknown) => {
+    setValues((previous) => {
+      const path = splitPath(name);
+      const updated = setNestedValue(previous, path, nextValue);
+      return updated;
+    });
+    setIsDirty(true);
+    setErrors((previous) => {
+      if (!previous[name]) {
+        return previous;
+      }
+      const copy = { ...previous };
+      delete copy[name];
+      return copy;
+    });
+  }, []);
+
+  const handleSubmit = useCallback<UseFormHandleSubmit<T>>(
+    (onValid, onInvalid) => async (event) => {
+      event?.preventDefault();
+      setIsSubmitting(true);
+      try {
+        let currentValues = values;
+        if (resolver) {
+          const result = await resolver(values);
+          currentValues = result.values;
+          if (Object.keys(result.errors).length > 0) {
+            setErrors(result.errors);
+            onInvalid?.(result.errors);
+            setIsSubmitting(false);
+            return;
+          }
+          setValues(result.values);
+        }
+        setErrors({});
+        await onValid(currentValues);
+      } catch (error) {
+        console.error('Form submission failed', error);
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [resolver, values],
+  );
+
+  const register = useCallback(
+    (name: string): RegisteredField<T> => ({
+      name,
+      value: getNestedValue(values, splitPath(name)),
+      onChange: (input) => {
+        if (input && typeof (input as ChangeEvent<HTMLInputElement>).target !== 'undefined') {
+          const event = input as ChangeEvent<HTMLInputElement>;
+          updateValue(name, event.target.type === 'number' ? event.target.valueAsNumber : event.target.value);
+        } else {
+          updateValue(name, input);
+        }
+      },
+      onBlur: () => undefined,
+    }),
+    [updateValue, values],
+  );
+
+  const setValue = useCallback((name: string, value: unknown) => {
+    updateValue(name, value);
+  }, [updateValue]);
+
+  const watch = useCallback(
+    (name?: string) => {
+      if (!name) {
+        return values;
+      }
+      return getNestedValue(values, splitPath(name));
+    },
+    [values],
+  );
+
+  const reset = useCallback((nextValues?: T) => {
+    const initial = nextValues ?? defaultValues;
+    setValues(initial);
+    setErrors({});
+    setIsDirty(false);
+  }, [defaultValues]);
+
+  const formState = useMemo<FormState<T>>(
+    () => ({
+      isSubmitting,
+      isDirty,
+      errors,
+    }),
+    [errors, isDirty, isSubmitting],
+  );
+
+  const form = useMemo<UseFormReturn<T>>(
+    () => ({
+      register,
+      handleSubmit,
+      setValue,
+      watch,
+      reset,
+      formState,
+      values,
+    }),
+    [formState, handleSubmit, register, reset, setValue, values, watch],
+  );
+
+  return form;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,8 @@
     "paths": {
       "@/*": ["./src/*"],
       "lucide-react": ["./lib/icons/lucide-react"],
-      "recharts": ["./src/lib/recharts"]
+      "recharts": ["./src/lib/recharts"],
+      "react-hook-form": ["./src/lib/react-hook-form"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## Summary
- add an AppSetting persistence model and helper utilities for managing workspace settings
- build a settings dashboard route with tabbed forms for general, display, business rules, and data tooling
- update analytics, dashboards, and reports to honour the configurable business-rule thresholds and new translations

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7b8afa9488321a23598e43fe25a74